### PR TITLE
fix(deps): update ferroni to 1.3.0 and settle the transformer boundary (ADR 0008)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,10 @@ logs
 node_modules
 temp
 tmp
-packages/colorized-brackets/src/themes.ts
-packages/shiki/src/langs
-packages/shiki/src/themes
-packages/shiki/src/*.json
-packages/shiki/src/langs
-packages/shiki/src/themes
+node/compat/upstream/shiki/packages/colorized-brackets/src/themes.ts
+node/compat/upstream/shiki/packages/shiki/src/langs
+node/compat/upstream/shiki/packages/shiki/src/themes
+node/compat/upstream/shiki/packages/shiki/src/*.json
 cache
 .eslintcache
 report-engine-js-compat.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [workspace.dependencies]
 bincode = "1.3"
-ferroni = "1.2.8"
+ferroni = "1.3.0"
 napi = { version = "2", default-features = false, features = [ "napi8" ] }
 napi-build = "2"
 napi-derive = "2"

--- a/adr/0008-transformers-and-decorations-stay-in-js.md
+++ b/adr/0008-transformers-and-decorations-stay-in-js.md
@@ -1,0 +1,51 @@
+# ADR 0008: Transformers And Decorations Stay In The JS Layer
+
+## Status
+
+Accepted
+
+## Context
+
+Rendering behavior such as `colorReplacements`, `mergeWhitespaces`,
+`mergeSameStyleTokens`, and the `codeToHast` render options has moved into the
+Rust core (see ADR 0001). Two features were still unassigned to either side of
+the native/JS boundary:
+
+- `transformers`: user-supplied callback hooks that receive hast nodes and
+  token structures at defined pipeline points. The Shiki ecosystem
+  (`@shikijs/transformers`, twoslash, colorized-brackets, and downstream
+  consumers such as Ardo's line-number/line-highlight transformers) depends on
+  this callback contract.
+- `decorations`: declarative offset ranges with classes/properties, applied to
+  the rendered output. Unlike transformers they carry data, not code.
+
+Today both are implemented entirely in the JS layer; the Rust core has no
+notion of either.
+
+## Decision
+
+The hast-level transformation surface stays in JavaScript. The native core
+owns tokenization, theme application, and rendering primitives, and exposes
+stable hast-shaped output for the JS layer to transform.
+
+- `transformers` stay in JS permanently. They are a JS-callback API by nature;
+  crossing the native boundary per hook invocation would add FFI overhead and
+  break the ecosystem contract that makes Ferriki a drop-in Shiki replacement.
+- `decorations` stay in JS for now. They interleave with transformers during
+  `codeToHast`, so applying them natively while transformers run in JS would
+  risk ordering drift against Shiki semantics. Because decorations are
+  declarative, native ownership remains possible later — but only as a
+  deliberate follow-up with compat coverage, not as a side effect of other
+  native migrations.
+
+## Consequences
+
+- The Rust core's public surface is token- and render-oriented; it does not
+  need to model callbacks or hast mutation.
+- Shiki ecosystem transformers keep working unchanged, which keeps the
+  drop-in story credible for consumers like Ardo.
+- The JS layer retains a bounded amount of runtime logic (transformer
+  dispatch, decoration application). This is a deliberate exception to the
+  "runtime behavior belongs in Rust" default of ADR 0001.
+- How much of the render pipeline can go native is now bounded: everything up
+  to hast construction may move down; hast mutation stays up.

--- a/plans/ferriki-remaining-work.md
+++ b/plans/ferriki-remaining-work.md
@@ -115,9 +115,9 @@ Exit criteria:
 
 ## 4. Decide Adapter Support Explicitly
 
-Status: largely done — ADR 0004 and ADR 0007 record the decisions, and the
-adapter lanes are outside the release gate. The native-vs-JS boundary below is
-still open.
+Status: done — ADR 0004 and ADR 0007 record the adapter decisions, the
+adapter lanes are outside the release gate, and ADR 0008 assigns
+`decorations` and `transformers` to the JS layer.
 
 Goal: stop treating historical integrations as implicit product requirements.
 
@@ -127,7 +127,7 @@ Separate and decide:
   - highlighting runtime
   - direct outputs
   - core compatibility surface
-- still-open native-vs-JS fallback boundary:
+- native-vs-JS boundary (decided in ADR 0008):
   - `decorations`
   - `transformers`
 - optional adapter lanes:


### PR DESCRIPTION
Two steps toward making ferriki consumable by Ardo (#14):

## ferroni 1.3.0

Bumps the regex engine from 1.2.8 to 1.3.0 — the first ferroni release since March (unblocked today via sebastian-software/ferroni#39). It carries the scanner/regex performance work (trie-based literal alternations, Aho-Corasick fast paths, thread-local match state) and compat_utf8 stabilization fixes.

Verified locally against the mirrored Shiki suites:
- core compat lane: 22 files, 91 tests passing
- adapter compat lane (transformers, twoslash): 17 files, 88 tests passing
- `cargo test -p ferriki-core`: 22 tests passing

## ADR 0008: transformers and decorations stay in the JS layer

Closes #13. Records what the code already does and why it should stay that way: the native core owns tokenization, theme application, and rendering primitives up to hast construction; hast-level mutation stays in JS. `transformers` remain a permanent JS callback contract (the Shiki ecosystem — `@shikijs/transformers`, twoslash, Ardo's line-number/line-highlight transformers — depends on it), `decorations` stay in JS for now because they interleave with transformers during `codeToHast`, with native ownership left open as a deliberate follow-up. Plan §4 is updated to point at the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD

---
_Generated by [Claude Code](https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD)_