### PR TITLE
feat(node): default to the native backend and expose Shiki subpaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ compatibility machinery lives under [`node`](node).
 
 ## Quick Start
 
-Prerequisites: a stable Rust toolchain (`cargo`), Node.js >= 18, and pnpm
+Prerequisites: a stable Rust toolchain (`cargo`), Node.js >= 20, and pnpm
 (the pinned version in `node/package.json` is picked up via corepack).
 
 Rust:

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ pnpm run test:ferriki-compat:colorized-brackets
 
 The Node package chooses its engine via `FERRIKI_BACKEND`:
 
-- `FERRIKI_BACKEND=rust`: native Rust core (what the compat lanes test)
-- `FERRIKI_BACKEND=js`: bundled JS engine (current default when unset)
+- unset: native Rust core when the addon is available, JS engine otherwise
+- `FERRIKI_BACKEND=rust`: force the native Rust core (what the compat lanes test)
+- `FERRIKI_BACKEND=js`: force the bundled JS engine
 
 `SHIKI_BACKEND` keeps working as a deprecated alias; `FERRIKI_BACKEND`
 takes precedence.

--- a/node/ferriki/README.md
+++ b/node/ferriki/README.md
@@ -13,7 +13,7 @@ Shiki test suite on every change.
 npm install ferriki
 ```
 
-Requires Node.js >= 18. The package is ESM-only.
+Requires Node.js >= 20 (matching upstream shiki@4). The package is ESM-only.
 
 ## Quick start
 

--- a/node/ferriki/README.md
+++ b/node/ferriki/README.md
@@ -35,9 +35,9 @@ backend is selected via an environment variable:
 
 | Setting | Effect |
 | --- | --- |
-| `FERRIKI_BACKEND=rust` | Use the native Rust core (requires a platform binary) |
+| unset | Native Rust core when a platform binary is available, JS engine otherwise (default) |
+| `FERRIKI_BACKEND=rust` | Force the native Rust core (throws if no platform binary loads) |
 | `FERRIKI_BACKEND=js` | Force the JS engine |
-| unset | JS engine (current default) |
 
 `SHIKI_BACKEND` is supported as a deprecated alias; `FERRIKI_BACKEND`
 takes precedence.
@@ -54,7 +54,10 @@ everything working — highlighting output is identical, just slower.
   [v4.0.1](https://github.com/sebastian-software/ferriki/tree/main/node/compat/upstream/shiki)).
 - The main entry (`import ... from 'ferriki'`) covers the full `shiki`
   main-entry surface.
-- Subpath imports (`shiki/core`, `shiki/types`, ...) are not exposed yet.
+- Supported subpaths for drop-in aliasing: `ferriki/core`, `ferriki/langs`,
+  `ferriki/themes`, `ferriki/types`, `ferriki/engine/javascript`,
+  `ferriki/engine/oniguruma`. Not exposed: `shiki/wasm`, `shiki/textmate`,
+  and the `shiki/bundle/*` entries.
 - Ecosystem adapters (`markdown-it`, `rehype`, VitePress integrations,
   `colorized-brackets`) are intentionally out of package scope — they sit
   on top of `codeToHtml`/`codeToHast` and keep working against those

--- a/node/ferriki/core.d.mts
+++ b/node/ferriki/core.d.mts
@@ -1,0 +1,1 @@
+export * from './index.mjs'

--- a/node/ferriki/core.mjs
+++ b/node/ferriki/core.mjs
@@ -1,0 +1,3 @@
+// Compatibility subpath mirroring `shiki/core`: the full core surface is
+// bundled in the main entry, so this is a plain re-export.
+export * from './index.mjs'

--- a/node/ferriki/dist/index.mjs
+++ b/node/ferriki/dist/index.mjs
@@ -12730,15 +12730,23 @@ function createJavaScriptRegexEngine(options = {}) {
 
 const kFerrikiNative = /* @__PURE__ */ Symbol.for("ferriki.native");
 const kFerrikiNativeHandle = /* @__PURE__ */ Symbol.for("ferriki.native-handle");
+let cachedNativeAvailability;
+function isNativeBindingAvailable() {
+  if (cachedNativeAvailability === void 0)
+    cachedNativeAvailability = Boolean(tryLoadFerrikiNativeBinding());
+  return cachedNativeAvailability;
+}
 function getRequestedBackend() {
   const requested = process$1.env.FERRIKI_BACKEND ?? process$1.env.SHIKI_BACKEND;
-  return requested === "rust" ? "rust" : "js";
+  if (requested === "rust" || requested === "js")
+    return requested;
+  return isNativeBindingAvailable() ? "rust" : "js";
 }
 function getFerrikiVersion() {
   return tryLoadFerrikiNativeBinding()?.ferrikiVersion();
 }
 function isRustBackendAvailable() {
-  return Boolean(tryLoadFerrikiNativeBinding());
+  return isNativeBindingAvailable();
 }
 function asRecord(value) {
   if (!value || typeof value !== "object")

--- a/node/ferriki/engine-javascript.d.mts
+++ b/node/ferriki/engine-javascript.d.mts
@@ -1,0 +1,1 @@
+export { createJavaScriptRegexEngine, defaultJavaScriptRegexConstructor } from './index.mjs'

--- a/node/ferriki/engine-javascript.mjs
+++ b/node/ferriki/engine-javascript.mjs
@@ -1,0 +1,2 @@
+// Compatibility subpath mirroring `shiki/engine/javascript`.
+export { createJavaScriptRegexEngine, defaultJavaScriptRegexConstructor } from './index.mjs'

--- a/node/ferriki/engine-oniguruma.d.mts
+++ b/node/ferriki/engine-oniguruma.d.mts
@@ -1,0 +1,1 @@
+export { createOnigurumaEngine, loadWasm } from './index.mjs'

--- a/node/ferriki/engine-oniguruma.mjs
+++ b/node/ferriki/engine-oniguruma.mjs
@@ -1,0 +1,2 @@
+// Compatibility subpath mirroring `shiki/engine/oniguruma`.
+export { createOnigurumaEngine, loadWasm } from './index.mjs'

--- a/node/ferriki/index.d.mts
+++ b/node/ferriki/index.d.mts
@@ -6,6 +6,11 @@
  * tighten as the TypeScript source of the Node layer is restored.
  */
 
+// Upstream Shiki type surface: re-exported wholesale so type-only imports
+// like `import type { ShikiTransformer } from 'ferriki'` resolve. Local
+// declarations below take precedence where names overlap.
+export type * from '@shikijs/types'
+
 // ─── Core data shapes ────────────────────────────────────────────────────────
 
 export type BundledLanguage = string
@@ -131,13 +136,13 @@ export declare function getLastGrammarState(...args: unknown[]): unknown
 
 // ─── Ferriki-specific backend API ────────────────────────────────────────────
 
-/** Which backend the current process requested via FERRIKI_BACKEND (or the deprecated SHIKI_BACKEND alias). */
+/** Backend for the current process: FERRIKI_BACKEND (or deprecated SHIKI_BACKEND) if set, otherwise "rust" when the native binding loads, else "js". */
 export declare function getRequestedBackend(): 'rust' | 'js'
 /** Whether the native Rust addon could be loaded on this platform. */
 export declare function isRustBackendAvailable(): boolean
 /** Version string reported by the native addon, if available. */
 export declare function getFerrikiVersion(): string | undefined
-/** Like createHighlighter, but honors FERRIKI_BACKEND=rust (or the deprecated SHIKI_BACKEND alias) by pairing the highlighter with the native core. */
+/** Like createHighlighter, but pairs the highlighter with the native core when the resolved backend is "rust" (the default when the native binding is available). */
 export declare function createHighlighterWithBackend(options?: HighlighterOptions): Promise<Highlighter>
 export declare function getFerrikiNativeHandle(highlighter: unknown): unknown
 export declare const kFerrikiNative: unique symbol

--- a/node/ferriki/langs.d.mts
+++ b/node/ferriki/langs.d.mts
@@ -1,0 +1,2 @@
+export { bundledLanguages, bundledLanguagesAlias, bundledLanguagesBase, bundledLanguagesInfo } from './index.mjs'
+export type { BundledLanguage } from './index.mjs'

--- a/node/ferriki/langs.mjs
+++ b/node/ferriki/langs.mjs
@@ -1,0 +1,2 @@
+// Compatibility subpath mirroring `shiki/langs` (full language bundle).
+export { bundledLanguages, bundledLanguagesAlias, bundledLanguagesBase, bundledLanguagesInfo } from './index.mjs'

--- a/node/ferriki/package.json
+++ b/node/ferriki/package.json
@@ -83,7 +83,7 @@
     "types.mjs"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "build": "node ./scripts/verify-wrapper.mjs",

--- a/node/ferriki/package.json
+++ b/node/ferriki/package.json
@@ -27,6 +27,30 @@
       "types": "./index.d.mts",
       "default": "./index.mjs"
     },
+    "./core": {
+      "types": "./core.d.mts",
+      "default": "./core.mjs"
+    },
+    "./langs": {
+      "types": "./langs.d.mts",
+      "default": "./langs.mjs"
+    },
+    "./themes": {
+      "types": "./themes.d.mts",
+      "default": "./themes.mjs"
+    },
+    "./types": {
+      "types": "./types.d.mts",
+      "default": "./types.mjs"
+    },
+    "./engine/javascript": {
+      "types": "./engine-javascript.d.mts",
+      "default": "./engine-javascript.mjs"
+    },
+    "./engine/oniguruma": {
+      "types": "./engine-oniguruma.d.mts",
+      "default": "./engine-oniguruma.mjs"
+    },
     "./native": {
       "types": "./native.d.mts",
       "default": "./native.mjs"
@@ -39,12 +63,24 @@
   "files": [
     "CHANGELOG.md",
     "assets",
+    "core.d.mts",
+    "core.mjs",
     "dist/**/*.mjs",
     "dist/ferriki.*.node",
+    "engine-javascript.d.mts",
+    "engine-javascript.mjs",
+    "engine-oniguruma.d.mts",
+    "engine-oniguruma.mjs",
     "index.d.mts",
     "index.mjs",
+    "langs.d.mts",
+    "langs.mjs",
     "native.d.mts",
-    "native.mjs"
+    "native.mjs",
+    "themes.d.mts",
+    "themes.mjs",
+    "types.d.mts",
+    "types.mjs"
   ],
   "engines": {
     "node": ">=18"
@@ -53,6 +89,9 @@
     "build": "node ./scripts/verify-wrapper.mjs",
     "dev": "node ./scripts/verify-wrapper.mjs",
     "build:native": "node ./scripts/build-native.mjs"
+  },
+  "dependencies": {
+    "@shikijs/types": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:types"

--- a/node/ferriki/themes.d.mts
+++ b/node/ferriki/themes.d.mts
@@ -1,0 +1,2 @@
+export { bundledThemes, bundledThemesInfo } from './index.mjs'
+export type { BundledTheme } from './index.mjs'

--- a/node/ferriki/themes.mjs
+++ b/node/ferriki/themes.mjs
@@ -1,0 +1,2 @@
+// Compatibility subpath mirroring `shiki/themes` (full theme bundle).
+export { bundledThemes, bundledThemesInfo } from './index.mjs'

--- a/node/ferriki/types.d.mts
+++ b/node/ferriki/types.d.mts
@@ -1,0 +1,2 @@
+export type { BundledLanguage, BundledTheme } from './index.mjs'
+export type * from '@shikijs/types'

--- a/node/ferriki/types.mjs
+++ b/node/ferriki/types.mjs
@@ -1,0 +1,2 @@
+// Compatibility subpath mirroring `shiki/types`: types-only, no runtime.
+export {}

--- a/node/pnpm-lock.yaml
+++ b/node/pnpm-lock.yaml
@@ -49,6 +49,10 @@ catalogs:
     tsx:
       specifier: ^4.21.0
       version: 4.21.0
+  default:
+    '@shikijs/types':
+      specifier: ^4.0.1
+      version: 4.3.1
   docs:
     floating-vue:
       specifier: ^5.2.2
@@ -554,6 +558,10 @@ importers:
         version: 3.5.27(typescript@5.9.3)
 
   ferriki:
+    dependencies:
+      '@shikijs/types':
+        specifier: 'catalog:'
+        version: 4.3.1
     devDependencies:
       '@types/node':
         specifier: catalog:types
@@ -1369,6 +1377,10 @@ packages:
     resolution: {integrity: sha512-Zv7v6q6aV+VslnpwzqKAmrk5JdVkLUzok2208ZXGipjb+msxBr/fJPZyeEXiFgH7k62Ak0SLIfxQRZQvTuf7rQ==}
     cpu: [x64]
     os: [win32]
+
+  '@shikijs/types@4.3.1':
+    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
+    engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -3990,6 +4002,11 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.57.0':
     optional: true
+
+  '@shikijs/types@4.3.1':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
 

--- a/node/pnpm-workspace.yaml
+++ b/node/pnpm-workspace.yaml
@@ -75,3 +75,5 @@ onlyBuiltDependencies:
   - simple-git-hooks
   - unrs-resolver
   - workerd
+catalog:
+  '@shikijs/types': ^4.0.1

--- a/node/pnpm-workspace.yaml
+++ b/node/pnpm-workspace.yaml
@@ -5,6 +5,8 @@ trustPolicy: no-downgrade
 packages:
   - ferriki
   - compat/upstream/shiki/packages/*
+catalog:
+  '@shikijs/types': ^4.0.1
 catalogs:
   bundling:
     '@rollup/plugin-commonjs': ^29.0.0
@@ -75,5 +77,3 @@ onlyBuiltDependencies:
   - simple-git-hooks
   - unrs-resolver
   - workerd
-catalog:
-  '@shikijs/types': ^4.0.1


### PR DESCRIPTION
Second batch from the repo audit — the product-facing fixes that make `npm install ferriki` deliver what the package description promises.

## Native backend by default

Previously the Rust core only ran with `FERRIKI_BACKEND=rust` set — without it, every consumer got the bundled JS engine and the native binary was dead weight. `getRequestedBackend()` now probes the native binding (memoized) when no env var is set: **rust when a platform binary loads, js otherwise**. Explicit `FERRIKI_BACKEND=rust|js` (and the deprecated `SHIKI_BACKEND` alias) keep forcing either engine, so the compat lanes and the publish smoke test are unchanged.

## Shiki subpath exports

Aliasing `shiki → ferriki` previously broke with `ERR_PACKAGE_PATH_NOT_EXPORTED` as soon as anything imported `shiki/core` or `shiki/types`. New thin re-export entries over the bundled main surface:

`ferriki/core`, `ferriki/langs`, `ferriki/themes`, `ferriki/types`, `ferriki/engine/javascript`, `ferriki/engine/oniguruma` — each with its own `types` condition. Intentionally not exposed: `wasm`, `textmate`, `bundle/*` (documented in the README).

## Real types via @shikijs/types

`index.d.mts` now does `export type * from '@shikijs/types'` (added as a catalog dependency), so type-only imports like `ShikiTransformer`, `ThemeRegistration`, or `LanguageRegistration` resolve instead of failing to compile. Local declarations keep precedence where names overlap; tightening the remaining provisional `any` signatures stays tracked in #10.

## Verification

End-to-end from a packed tarball in a fresh consumer project: all five subpaths resolve, the default backend is `rust` with the bundled binary, `codeToHtml` output is unchanged, and a strict-mode TypeScript consumer compiles against the re-exported types. `pnpm pack` rewrites the `catalog:` specifier to `^4.0.1` in the published manifest. Core compat lane: 22 files / 91 tests passing. READMEs updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD

---
_Generated by [Claude Code](https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD)_