### PR TITLE
docs: adopt ADR 0009 — native-only runtime, JS engine deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ The Node package chooses its engine via `FERRIKI_BACKEND`:
 
 - unset: native Rust core when the addon is available, JS engine otherwise
 - `FERRIKI_BACKEND=rust`: force the native Rust core (what the compat lanes test)
-- `FERRIKI_BACKEND=js`: force the bundled JS engine
+- `FERRIKI_BACKEND=js`: force the bundled JS engine (deprecated per
+  [ADR 0009](adr/0009-native-only-runtime.md) — Ferriki is a native-only
+  runtime; the JS engine will be removed once multi-platform binaries
+  have shipped)
 
 `SHIKI_BACKEND` keeps working as a deprecated alias; `FERRIKI_BACKEND`
 takes precedence.

--- a/adr/0009-native-only-runtime.md
+++ b/adr/0009-native-only-runtime.md
@@ -27,12 +27,14 @@ justification as a product component.
 
 ## Decision
 
-Ferriki is a native-only runtime.
+Ferriki is a native-only runtime. This describes the target state the
+cut-over release ships; until then the deprecated JS engine remains in
+the package solely as the fallback for platforms without a binary.
 
-- The published package executes highlighting exclusively in the Rust
-  core. JavaScript remains only as a thin facade: addon loading, public
-  API wiring, hast-level transformation (transformers and decorations per
-  ADR 0008), and the type surface.
+- Target state: the published package executes highlighting exclusively
+  in the Rust core. JavaScript remains only as a thin facade: addon
+  loading, public API wiring, hast-level transformation (transformers and
+  decorations per ADR 0008), and the type surface.
 - The bundled JS engine is deprecated as of this decision and will be
   removed once the multi-platform binaries have shipped in a published
   release. `FERRIKI_BACKEND=js` is deprecated with it and will be removed

--- a/adr/0009-native-only-runtime.md
+++ b/adr/0009-native-only-runtime.md
@@ -1,0 +1,64 @@
+# ADR 0009: Native-Only Runtime — JS Is A Facade, WASM Is The Future Fallback
+
+## Status
+
+Accepted
+
+## Context
+
+Ferriki started from a Shiki-shaped workbench so the upstream test suite
+stayed runnable 1:1 while behavior was ported selectively. That transition
+left two artifacts in the published package that contradict the Rust-first
+goal of ADR 0001:
+
+- the full vendored Shiki JS engine still ships (the bundled entry plus
+  ~300 chunk files of JS grammars/themes), reachable via
+  `FERRIKI_BACKEND=js` and used as the fallback on platforms without a
+  native binary
+- the native path is wired through a parity adapter that first constructs
+  the complete JS highlighter and then delegates to the Rust core — the
+  Rust engine currently hangs off the JS scaffolding, not the other way
+  around
+
+With multi-platform prebuilds (linux-x64/arm64, darwin-x64/arm64,
+win32-x64) shipping through the release pipeline, and with the Rust stack
+(including ferroni) able to target `wasm32`, the JS engine no longer has a
+justification as a product component.
+
+## Decision
+
+Ferriki is a native-only runtime.
+
+- The published package executes highlighting exclusively in the Rust
+  core. JavaScript remains only as a thin facade: addon loading, public
+  API wiring, hast-level transformation (transformers and decorations per
+  ADR 0008), and the type surface.
+- The bundled JS engine is deprecated as of this decision and will be
+  removed once the multi-platform binaries have shipped in a published
+  release. `FERRIKI_BACKEND=js` is deprecated with it and will be removed
+  in the same step.
+- Platforms without a native binary fail with a clear, actionable error.
+  The intended answer for environments the prebuild matrix cannot reach —
+  including browsers — is a future `wasm32` build of the Rust core, not a
+  JS reimplementation.
+- The strict upstream mirror under `node/compat/upstream` is unaffected:
+  it is a development-only test oracle, never shipped, and remains the
+  measure of Shiki compatibility.
+
+## Consequences
+
+- Issue #10 is reframed: the Node layer's missing TypeScript source is
+  not recovered from the historical bundle — the facade the end state
+  needs is written fresh, validated against the mirrored compat suites.
+- The parity adapter inverts: `createHighlighter` and the shorthand
+  functions call the native binding directly; any operation the Rust core
+  cannot serve is a gap to close in `crates/ferriki-core`, not a reason to
+  run JS.
+- The legacy JS bundle assets (issue #11) and the JS engine paths are
+  removed in the cut-over release, with a CI guard that keeps removed
+  runtime paths from returning.
+- Removing the fallback is a breaking change for platforms outside the
+  prebuild matrix and is shipped as a deliberate minor release while
+  Ferriki is pre-1.0.
+- Per-platform sidecar packages become practical once the tarball no
+  longer needs the JS engine as a universality guarantee.

--- a/node/ferriki/README.md
+++ b/node/ferriki/README.md
@@ -37,7 +37,7 @@ backend is selected via an environment variable:
 | --- | --- |
 | unset | Native Rust core when a platform binary is available, JS engine otherwise (default) |
 | `FERRIKI_BACKEND=rust` | Force the native Rust core (throws if no platform binary loads) |
-| `FERRIKI_BACKEND=js` | Force the JS engine |
+| `FERRIKI_BACKEND=js` | Force the bundled JS engine (deprecated, see below) |
 
 `SHIKI_BACKEND` is supported as a deprecated alias; `FERRIKI_BACKEND`
 takes precedence.
@@ -45,8 +45,15 @@ takes precedence.
 ## Platform support
 
 Native binaries are built for linux-x64, linux-arm64, darwin-x64,
-darwin-arm64, and win32-x64. On other platforms the JS engine keeps
-everything working — highlighting output is identical, just slower.
+darwin-arm64, and win32-x64. On other platforms the bundled JS engine
+currently keeps everything working — highlighting output is identical,
+just slower. The JS engine is deprecated: Ferriki is a native-only
+runtime by decision
+([ADR 0009](https://github.com/sebastian-software/ferriki/blob/main/adr/0009-native-only-runtime.md)),
+and the JS fallback will be removed once multi-platform binaries have
+shipped; platforms outside the prebuild matrix will then get a clear
+error, with a WebAssembly build of the Rust core as the intended
+long-term answer.
 
 ## Shiki compatibility
 

--- a/plans/ferriki-remaining-work.md
+++ b/plans/ferriki-remaining-work.md
@@ -27,7 +27,7 @@ Already true:
 Not done yet:
 
 - the transitional JS bundle assets under `node/ferriki/dist/chunks` still
-  back the JS engine path
+  back the JS engine path (removal decided in ADR 0009)
 - the Node package source of truth is the checked-in `dist` bundle; there is
   no TS source for it in the repo
 - the shipped `index.d.mts` types most of the compat surface as `any`


### PR DESCRIPTION
Records the product decision that resolves the fork legacy for good: **Ferriki is a native-only runtime.**

## The decision (ADR 0009)

- The published package executes highlighting exclusively in the Rust core. JavaScript remains only as a thin facade: addon loading, public API wiring, hast-level transformation (transformers/decorations per ADR 0008), and the type surface.
- The bundled JS engine and `FERRIKI_BACKEND=js` are **deprecated as of this decision** and will be removed once the multi-platform binaries have shipped in a published release.
- Platforms without a native binary will fail with a clear, actionable error. The intended answer for environments outside the prebuild matrix — including browsers — is a future `wasm32` build of the Rust core, not a JS reimplementation.
- The strict upstream mirror under `node/compat/upstream` is unaffected: it is the development-only compatibility oracle and never ships.

## Consequences captured in the ADR

- Issue #10 is reframed: the Node layer's TypeScript source is written fresh as the thin facade the end state needs, validated against the mirrored compat suites — not recovered from the historical bundle.
- The parity adapter inverts (native-first instead of JS-scaffold-first); anything the Rust core cannot serve is a gap to close in `crates/ferriki-core`.
- The legacy JS bundle assets (#11) go with the cut-over, guarded by CI against reintroduction; per-platform sidecar packages become practical after it.

Both READMEs and `plans/ferriki-remaining-work.md` carry the deprecation notes and link the ADR. A detailed gap analysis of what still runs in JS when the Rust backend is active (the concrete work plan for the migration) is in progress and will be posted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD

---
_Generated by [Claude Code](https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD)_