### PR TITLE
test: honest-alias mode for the compat lane, and the measured gate verdict

### DIFF
--- a/node/vitest.config.ts
+++ b/node/vitest.config.ts
@@ -18,9 +18,30 @@ function defaultExportInteropExpression(source: string) {
   ].join(' ?? ')
 }
 
+const backendEntry = new URL('./compat/harness/shiki-backend-entry.ts', import.meta.url).pathname
+
 export default defineConfig({
   plugins: [
     tsconfigPaths(),
+    {
+      // Honest-alias mode (FERRIKI_HONEST_ALIAS=1): route the mirrored
+      // tests' remaining upstream entry points through the ferriki backend
+      // entry, so the compat lane exercises the native path instead of
+      // upstream JS against upstream JS (migration plan, Finding 0).
+      name: 'ferriki-honest-alias',
+      enforce: 'pre' as const,
+      resolveId(source: string, importer?: string) {
+        if (!process.env.FERRIKI_HONEST_ALIAS)
+          return
+        if (source === 'shiki/bundle/full' || source === 'shiki/core')
+          return backendEntry
+        if (source === '../src' && importer && (
+          importer.includes('/compat/upstream/shiki/packages/shiki/test/')
+          || importer.includes('/compat/upstream/shiki/packages/core/test/')
+        ))
+          return backendEntry
+      },
+    },
     {
       name: 'ferriki-compat-subpath-loader',
       resolveId(id) {

--- a/node/vitest.config.ts
+++ b/node/vitest.config.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
@@ -38,8 +39,9 @@ export default defineConfig({
         if (source === '../src' && importer && (
           importer.includes('/compat/upstream/shiki/packages/shiki/test/')
           || importer.includes('/compat/upstream/shiki/packages/core/test/')
-        ))
+        )) {
           return backendEntry
+        }
       },
     },
     {

--- a/plans/native-only-migration.md
+++ b/plans/native-only-migration.md
@@ -145,11 +145,49 @@ thin napi facade, no JS engine. The only variable is the provenance of
 the tokenizer core, and that choice should be made from the measured pass
 rate, not from sentiment about the fork era.
 
+## Gate result (measured 2026-07-26)
+
+The honest-alias mode exists (`FERRIKI_HONEST_ALIAS=1` in
+`node/vitest.config.ts`, off by default) and the gate has been measured.
+Raw result: 63/91 tests pass natively. Classification of the 28 failures
+(each root-caused, with a `FERRIKI_BACKEND=js` control run to separate
+facade artifacts from native defects): 14 cataloged G-gaps/facade bugs,
+6 test-infrastructure artifacts of the aliasing itself, and **8
+tokenization-structural failures**.
+
+Gate metric: 63 of 71 tokenization-asserting cases = **88.7%**, below
+the 90% threshold — and four distinct structural failure classes exist,
+all on content the vendored JS engine renders correctly from identical
+assets:
+
+1. Theme resolution ignores ancestor scopes (rules matching
+   `meta.function-call` or `string.quoted` via the scope stack resolve to
+   the default color natively).
+2. `fontStyle` inheritance is broken (NotSet semantics: a
+   foreground-only specific rule drops the italic/bold a broader rule
+   provides).
+3. While-rule / capture scope-stack handling fails in markdown
+   (mid-line `markup.quote` loss with token-boundary drift, heading `#`
+   captures not split, begin-captures losing `entity.name.tag`).
+4. Embedded-language delegation never enters `source.js` inside markdown
+   fences or `source.css.scss` inside Vue `<style>` blocks, while
+   html→js `<script>` embedding works — an inconsistency in the
+   contentName/include machinery.
+
+Classes 3 and 4 are squarely in the structural set the gate names;
+classes 1 and 2 are systematic theme-resolver semantics. **Both re-port
+conditions are met. Decision: re-port the core** as a mechanical 1:1
+port of vscode-textmate onto ferroni's Scanner API, with the upstream
+vscode-textmate suite mirrored as the oracle. The asset pipeline and the
+Shiki compat mirror carry over; the current core remains as a reference
+implementation until parity. The theme-resolver findings (classes 1–2)
+double as a known-issues list for the interim native path.
+
 ## Suggested sequence
 
-1. **Fix the compat-lane aliasing** (Finding 0) — makes the true native
-   pass rate visible; expect new failures, which become the work list and
-   feed the decision gate above.
+1. **Done:** the compat-lane aliasing fix exists as the opt-in
+   honest-alias mode, and the decision gate has been measured (see Gate
+   result above); outcome: re-port.
 2. Fix the standalone bugs above (silent `grammarState` drop, error
    rewrapping, alias clobbering, catalog diagnostics).
 3. Land the S-gaps (G1–G7).


### PR DESCRIPTION
Runs the experiment the migration plan called for — and records its verdict.

## Honest-alias mode

`FERRIKI_HONEST_ALIAS=1` (new opt-in plugin in `node/vitest.config.ts`, off by default — the regular lane is unchanged) routes the mirrored tests' remaining upstream entry points (`'../src'` from `shiki/test` and `core/test`, `shiki/bundle/full`, `shiki/core`) through the ferriki backend entry, so the compat lane finally exercises the native path instead of upstream JS against upstream JS (Finding 0).

## Measured gate result

Raw: **63/91 tests pass natively.** All 28 failures were root-caused individually, with a `FERRIKI_BACKEND=js` control run separating facade artifacts from native defects: 14 cataloged G-gaps/facade bugs, 6 aliasing test-infrastructure artifacts, and **8 tokenization-structural failures** in four distinct classes:

1. Theme resolution ignores ancestor scopes (min-light/min-dark rules resolving via the scope stack fall back to the default color).
2. `fontStyle` NotSet inheritance is broken (a foreground-only specific rule drops italic/bold from a broader rule).
3. While-rule/capture scope-stack handling fails in markdown (mid-line `markup.quote` loss with token-boundary drift, unsplit heading captures, lost `entity.name.tag` begin-captures).
4. Embedded-language delegation never enters `source.js` in markdown fences or `source.css.scss` in Vue `<style>` blocks — while html→js embedding works.

Gate metric: **63/71 = 88.7%** (below the 90% threshold) **and** structural classes 3–4 are exactly the set the gate names as architecture-not-bugs. Both re-port conditions are met.

**Decision recorded in the plan: re-port the core** as a mechanical 1:1 port of vscode-textmate onto ferroni's Scanner API, with the upstream vscode-textmate suite mirrored as the oracle — the methodology that built ferroni. The asset pipeline and Shiki compat mirror carry over; the current core stays as a reference implementation until parity, and the theme-resolver findings double as the interim known-issues list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD

---
_Generated by [Claude Code](https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD)_