### PR TITLE
test(core): remove timing from semantic assertions

### DIFF
--- a/crates/ferriki-core/src/highlighter.rs
+++ b/crates/ferriki-core/src/highlighter.rs
@@ -336,6 +336,13 @@ mod tests {
         HighlighterCore::with_standard_assets(&root).expect("highlighter")
     }
 
+    fn unlimited_tokenize_options() -> TokenizeOptions {
+        TokenizeOptions {
+            time_limit_millis: 0,
+            ..TokenizeOptions::default()
+        }
+    }
+
     #[test]
     fn loads_standard_language_dependencies_and_aliases() {
         let mut highlighter = standard_highlighter();
@@ -462,7 +469,7 @@ mod tests {
                 "console.log(\"Hi\")",
                 "javascript",
                 "nord",
-                &TokenizeOptions::default(),
+                &unlimited_tokenize_options(),
             )
             .expect("tokens");
 
@@ -502,6 +509,7 @@ mod tests {
                 "javascript",
                 "nord",
                 &TokenizeOptions {
+                    time_limit_millis: 0,
                     include_token_type: true,
                     ..TokenizeOptions::default()
                 },

--- a/crates/ferriki-core/src/napi_api.rs
+++ b/crates/ferriki-core/src/napi_api.rs
@@ -191,6 +191,7 @@ mod tests {
             "lang": "javascript",
             "theme": "nord",
             "includeExplanation": "tokenType",
+            "tokenizeTimeLimit": 0,
         })
         .to_string();
 

--- a/crates/ferriki-core/src/render.rs
+++ b/crates/ferriki-core/src/render.rs
@@ -275,7 +275,15 @@ mod tests {
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../assets/shiki");
         HighlighterCore::with_standard_assets(&root)
             .expect("highlighter")
-            .tokenize(code, "javascript", "nord", &TokenizeOptions::default())
+            .tokenize(
+                code,
+                "javascript",
+                "nord",
+                &TokenizeOptions {
+                    time_limit_millis: 0,
+                    ..TokenizeOptions::default()
+                },
+            )
             .expect("tokens")
     }
 

--- a/crates/ferriki-core/src/tokens.rs
+++ b/crates/ferriki-core/src/tokens.rs
@@ -115,6 +115,18 @@ mod tests {
     use super::*;
 
     #[test]
+    fn defaults_to_shiki_tokenization_limits() {
+        assert_eq!(
+            TokenizeOptions::default(),
+            TokenizeOptions {
+                time_limit_millis: 500,
+                max_line_length: 0,
+                include_token_type: false,
+            }
+        );
+    }
+
+    #[test]
     fn splits_crlf_lines_with_global_utf16_offsets() {
         assert_eq!(
             split_lines("😀a\r\nb\n"),


### PR DESCRIPTION
Follow-up to #34.

## What changed

- run token, renderer, and N-API semantic fixtures with `tokenizeTimeLimit: 0`
- keep the production default unchanged at Shiki's 500 ms
- add a dedicated regression assertion for the default tokenization limits

## Why

The first #34 CI run exposed a debug-only timing dependency. On a cold Linux runner, ferroni's lazy grammar compilation can consume the production 500 ms tokenization budget before a short JavaScript fixture reaches the closing quote. The tokenizer then correctly returns an intentionally early-stopped token stream, but exact semantic assertions interpret that as a grammar mismatch.

The native Shiki compatibility gate on the same Linux workflow was green, and the failure varied between identical Core tests across reruns. Correctness fixtures should not include compiler/startup performance in their semantic expectations.

## Impact

There is no runtime behavior change. User-facing tokenization still defaults to 500 ms, matching Shiki v4.3.1. Only correctness-focused test fixtures opt out of the time limit.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p ferriki-core` — 21 passed
- `cargo test --workspace` — all unit, integration, doc, and mirrored vscode-textmate oracle tests passed