### PR TITLE
fix(compat): upgrade Ferroni to 1.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "ferroni"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d82d0d318369016aeadfb143999702706370e20ec7ed7d3a555145abce2e6b9"
+checksum = "17cc9a864ddcc251bf4d2c5db586a6a5f963159ea8a6c248c30decde630c53a4"
 dependencies = [
  "aho-corasick",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 
 [workspace.dependencies]
 bincode = "1.3"
-ferroni = "1.3.0"
+ferroni = "1.3.2"
 napi = { version = "2", default-features = false, features = [ "napi8" ] }
 napi-build = "2"
 napi-derive = "2"

--- a/crates/ferriki-core/README.md
+++ b/crates/ferriki-core/README.md
@@ -14,6 +14,10 @@ Ferriki is intentionally split like this:
 - `node/ferriki`: Node package and compatibility-facing entrypoint
 - `ferroni`: external regex dependency, not a vendored repository component
 
+The scanner compatibility baseline is Ferroni **1.3.2 or newer within the
+1.x release line**. The workspace lockfile pins the release used by CI; any
+Ferroni upgrade must rerun the TextMate oracle and Shiki compatibility lanes.
+
 The design target is that runtime behavior is defined here first. JavaScript is
 there to load the addon, expose the public API, and keep compatibility stable,
 not to reimplement the highlighter.

--- a/crates/ferriki-textmate/src/regexp.rs
+++ b/crates/ferriki-textmate/src/regexp.rs
@@ -559,6 +559,18 @@ impl<T: Copy> CompiledRule<T> {
             capture_indices: matched.capture_indices,
         });
 
+        // Ferroni 1.3.2 reports a `^$` match at the synthetic end position
+        // used by TextMate's line scanner. That position is valid for `$`,
+        // but not for a line-start anchor after the line terminator. Keep the
+        // TextMate distinction here rather than weakening the shared Scanner
+        // semantics for other callers.
+        if best.as_ref().is_some_and(|best| {
+            has_line_start_anchor(&self.reg_exps[best.index])
+                && best.capture_indices[0].start == string.utf16_len()
+        }) {
+            best = None;
+        }
+
         if options == ScannerFindOptions::NONE {
             // Ferroni 1.3's RegSet path can miss a valid lookaround match or
             // return a later start for some extended-mode TextMate patterns.

--- a/crates/ferriki-textmate/src/regexp.rs
+++ b/crates/ferriki-textmate/src/regexp.rs
@@ -559,14 +559,16 @@ impl<T: Copy> CompiledRule<T> {
             capture_indices: matched.capture_indices,
         });
 
-        // Ferroni 1.3.2 reports a `^$` match at the synthetic end position
-        // used by TextMate's line scanner. That position is valid for `$`,
-        // but not for a line-start anchor after the line terminator. Keep the
-        // TextMate distinction here rather than weakening the shared Scanner
-        // semantics for other callers.
+        // Ferroni reports line-guard matches at the synthetic end position
+        // used by TextMate's line scanner. These guards are valid at the
+        // logical line start, but not after the line terminator. Keep the
+        // TextMate distinction here rather than weakening shared Scanner
+        // semantics for regular expression consumers.
         if best.as_ref().is_some_and(|best| {
-            has_line_start_anchor(&self.reg_exps[best.index])
-                && best.capture_indices[0].start == string.utf16_len()
+            let pattern = self.reg_exps[best.index].trim();
+            best.capture_indices[0].start == string.utf16_len()
+                && (pattern == "^$"
+                    || (start_position < string.utf16_len() && rejects_artificial_end(pattern)))
         }) {
             best = None;
         }
@@ -585,8 +587,10 @@ impl<T: Copy> CompiledRule<T> {
                 else {
                     continue;
                 };
-                if fallback.rejects_artificial_end && capture_indices[0].start == string.utf16_len()
-                {
+                let pattern = self.reg_exps[index].trim();
+                let rejects_artificial_end = fallback.rejects_artificial_end
+                    || (start_position < string.utf16_len() && rejects_artificial_end(pattern));
+                if rejects_artificial_end && capture_indices[0].start == string.utf16_len() {
                     continue;
                 }
                 let should_replace = best.as_ref().is_none_or(|best| {
@@ -667,6 +671,13 @@ fn normalize_ferroni_pattern(pattern: &str) -> String {
         position += character.len_utf8();
     }
     result
+}
+
+fn rejects_artificial_end(pattern: &str) -> bool {
+    pattern == "$"
+        || pattern.starts_with("^\\s*")
+        || pattern.starts_with("^(?!")
+        || pattern.starts_with("(^|\\G)(?!")
 }
 
 fn has_line_start_anchor(pattern: &str) -> bool {


### PR DESCRIPTION
## Summary

- upgrade the workspace Ferroni compatibility baseline from 1.3.0 to 1.3.2
- preserve TextMate semantics when Ferroni reports ^$ at the synthetic end-of-line position
- document the supported Ferroni 1.x baseline and validation policy

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- pnpm run test:ferriki-compat:textmate

Fixes #58