### PR TITLE
feat: formalize Ferromark and Ardo adapter contract

### DIFF
--- a/docs/examples/ferromark-ardo.mjs
+++ b/docs/examples/ferromark-ardo.mjs
@@ -1,40 +1,61 @@
-import { createHighlighter } from 'ferriki'
+import { fileURLToPath } from 'node:url'
 
-const highlighter = await createHighlighter({
-  langs: ['typescript', 'markdown'],
-  themes: ['nord', 'vitesse-light'],
-})
+const { createHighlighter } = await import(process.env.FERRIKI_PACKAGE_PATH || 'ferriki')
 
 /**
- * Minimal synchronous adapter shape consumed by Ferromark 0.8.
- * Ardo remains responsible for the surrounding code-block container.
+ * Build the synchronous highlighter contract consumed by Ferromark 0.8.
+ *
+ * The async factory boundary is intentional: Ardo/Ferromark must finish
+ * loading every language used by a document before fenced rendering starts.
+ * Ardo still owns the surrounding figure, title, label, line metadata, and
+ * trusted-output decision.
  */
-export function createFerrikiCodeHighlighter() {
+export async function createFerrikiCodeHighlighter({
+  languages = ['typescript', 'markdown'],
+  lightTheme = 'vitesse-light',
+  darkTheme = 'nord',
+  onDiagnostic = diagnostic => console.warn(`[ferriki] ${diagnostic.message}`),
+} = {}) {
+  const highlighter = await createHighlighter({
+    langs: languages,
+    themes: [lightTheme, darkTheme],
+  })
+
   return {
     codeToHtml(code, { lang = 'text', meta = {} } = {}) {
+      const rawMeta = typeof meta?.__raw === 'string' ? meta.__raw : ''
       try {
         return highlighter.codeToHtml(code, {
           lang,
           themes: {
-            light: 'vitesse-light',
-            dark: 'nord',
+            light: lightTheme,
+            dark: darkTheme,
           },
           defaultColor: false,
-          meta: {
-            __raw: String(meta.__raw || ''),
-          },
+          // Ferromark's fence parser owns this opaque string. Ferriki never
+          // interpolates it into HTML; Ardo parses title/label attributes.
+          meta: { __raw: rawMeta },
         })
       }
-      catch (error) {
-        console.warn(`[ferriki] falling back to escaped ${lang} block: ${error}`)
-        return escapeHtml(code)
+      catch (cause) {
+        const message = `Code highlighting failed for language ${JSON.stringify(lang)}; using escaped plaintext.`
+        onDiagnostic({
+          code: 'FERRIKI_HIGHLIGHT_FALLBACK',
+          language: lang,
+          message,
+          cause,
+        })
+        return `<pre class="ferriki-fallback language-${escapeAttribute(lang)}"><code>${escapeHtml(code)}</code></pre>`
       }
+    },
+    dispose() {
+      highlighter.dispose()
     },
   }
 }
 
 function escapeHtml(value) {
-  return value.replace(/[&<>"']/g, character => ({
+  return String(value).replace(/[&<>"']/g, character => ({
     '&': '&amp;',
     '<': '&lt;',
     '>': '&gt;',
@@ -43,23 +64,28 @@ function escapeHtml(value) {
   })[character])
 }
 
-const adapter = createFerrikiCodeHighlighter()
-const rendered = adapter.codeToHtml('const answer = 42', {
-  lang: 'typescript',
-  meta: { __raw: '{title="example.ts"}' },
-})
-if (!rendered.includes('shiki'))
-  throw new Error('Ferriki example did not render highlighted HTML')
+function escapeAttribute(value) {
+  return escapeHtml(value)
+}
 
-const hast = highlighter.codeToHast('const answer = 42', {
-  lang: 'typescript',
-  theme: 'nord',
-})
-const tokens = highlighter.codeToTokens('const answer = 42', {
-  lang: 'typescript',
-  theme: 'nord',
-})
-if (hast.type !== 'root' || tokens.tokens.length === 0)
-  throw new Error('Ferriki example did not produce HAST and token output')
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const adapter = await createFerrikiCodeHighlighter()
+  const rendered = adapter.codeToHtml('const answer = 42', {
+    lang: 'typescript',
+    meta: { __raw: '{title="example.ts"}' },
+  })
+  if (!rendered.includes('shiki-themes') || !rendered.includes('class="line"'))
+    throw new Error('Ferriki example did not render the dual-theme line contract')
 
-console.log('Ferriki + Ferromark adapter example rendered successfully')
+  const hastHighlighter = await createHighlighter({ langs: ['typescript'], themes: ['nord'] })
+  const hast = hastHighlighter.codeToHast('const answer = 42', {
+    lang: 'typescript',
+    theme: 'nord',
+  })
+  if (hast.type !== 'root')
+    throw new Error('Ferriki example did not produce HAST output')
+
+  adapter.dispose()
+  hastHighlighter.dispose()
+  console.log('Ferriki + Ferromark adapter example rendered successfully')
+}

--- a/docs/ferriki-1.0-api-contract.md
+++ b/docs/ferriki-1.0-api-contract.md
@@ -65,7 +65,7 @@ compatibility tests must converge on this matrix.
 | `theme` | Stable | Single-theme rendering with deterministic class, foreground, and background output. |
 | `themes` | Stable | Ordered theme map for light/dark or multi-theme output; never silently collapsed to one theme. `defaultColor: false` emits CSS variables for every theme. |
 | `defaultColor` | Stable | `light`, `dark`, a named theme, or `false`; invalid combinations throw `ShikiError` (#43). |
-| `meta` | Stable | Opaque fence metadata passed through the JS facade for Ferromark/Ardo integration (#55), without changing the source trust boundary. |
+| `meta` | Stable | Opaque fence metadata passed through the JS facade for Ferromark/Ardo integration (#55), without changing the source trust boundary. Ardo parses title/label/line attributes; Ferriki never interpolates `meta.__raw` into HTML. |
 | `transformers` | Stable | JS callbacks run in the documented HAST/token pipeline order (ADR 0008, #45). |
 | `decorations` | Stable | Declarative ranges are validated and applied in the JS rendering layer (ADR 0008, #45). |
 | `includeExplanation` | Stable | `true`, `scopeName`, and `tokenType` produce the documented explanation shape (#47). |
@@ -112,8 +112,8 @@ compatibility tests must converge on this matrix.
 | Synchronous fenced rendering | `Highlighter.codeToHtml()` | #42, #55 |
 | Lazy language/theme discovery | Enumerable catalogs and loader inputs | #44, #46 |
 | Light/dark output | `themes`, `defaultColor`, aligned tokens | #43 |
-| Line/title/fence metadata | `meta`, HAST line properties | #45, #55 |
-| Safe unknown-language fallback | `ShikiError` taxonomy and adapter policy | #50, #55 |
+| Line/title/fence metadata | `meta`, HAST line properties; Ardo owns container/title/line attributes | #45, #55 |
+| Safe unknown-language fallback | `ShikiError` taxonomy and the public adapter's escaped fallback/diagnostic policy | #50, #55 |
 | Line highlighting/decorations | JS transformer/decorator pipeline | #45, ADR 0008 |
 | No private native calls | Node exports only | #10, #31 |
 

--- a/docs/migrations/shiki-to-ferriki.md
+++ b/docs/migrations/shiki-to-ferriki.md
@@ -76,6 +76,19 @@ policy; Ferriki owns highlighting and HAST/HTML/token output. The contract and
 representative executable consumer are documented in
 [`docs/examples/ferromark-ardo.mjs`](../examples/ferromark-ardo.mjs).
 
+The executable contract in `node/scripts/check-ferromark-ardo-contract.mjs`
+asserts the integration boundary:
+
+- the synchronous `codeToHtml(code, { lang, meta })` handoff emits aligned
+  light/dark Shiki output with `.line` elements;
+- `meta.__raw` remains opaque to Ferriki, so Ardo can safely parse title/label
+  metadata and attach its own figure/line attributes;
+- source and fence metadata never cross into fallback HTML unescaped;
+- an unsupported language returns one escaped plaintext block and one
+  actionable `FERRIKI_HIGHLIGHT_FALLBACK` diagnostic;
+- the adapter uses only public Ferriki APIs and performs language loading at
+  its async construction boundary.
+
 ## Rollback
 
 Keep the Shiki adapter behind the same highlighter interface while migrating.

--- a/node/package.json
+++ b/node/package.json
@@ -24,6 +24,7 @@
     "check:release": "node ./scripts/check-release-workflow.mjs",
     "check:transformers": "node ./scripts/check-ferriki-transformers.mjs",
     "check:token-state": "node ./scripts/check-ferriki-token-state.mjs",
+    "check:ferromark-ardo": "node ./scripts/check-ferromark-ardo-contract.mjs",
     "check:docs": "node ./scripts/check-docs-contract.mjs && node ./scripts/check-packed-consumer.mjs",
     "publish:ci": "pnpm -C ferriki publish --access public --no-git-checks"
   },

--- a/node/scripts/check-ferromark-ardo-contract.mjs
+++ b/node/scripts/check-ferromark-ardo-contract.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+process.env.FERRIKI_PACKAGE_PATH = new URL('../ferriki/index.mjs', import.meta.url).href
+const exampleModuleUrl = new URL('../../docs/examples/ferromark-ardo.mjs', import.meta.url)
+const { createFerrikiCodeHighlighter } = await import(exampleModuleUrl.href)
+
+const exampleSource = await readFile(fileURLToPath(new URL('../../docs/examples/ferromark-ardo.mjs', import.meta.url)), 'utf8')
+assert(!exampleSource.includes('native.'))
+assert(!exampleSource.includes('resolveGrammarScope'))
+
+const diagnostics = []
+const adapter = await createFerrikiCodeHighlighter({
+  languages: ['typescript'],
+  onDiagnostic: diagnostic => diagnostics.push(diagnostic),
+})
+
+try {
+  const html = adapter.codeToHtml('const answer = 42', {
+    lang: 'typescript',
+    meta: { __raw: '{title="trusted-by-ardo" label="example"}' },
+  })
+  assert.match(html, /class="shiki-themes vitesse-light nord"/)
+  assert.match(html, /class="line"/)
+  assert.match(html, /--shiki-light:/)
+  assert.match(html, /--shiki-dark:/)
+  assert(!html.includes('trusted-by-ardo'))
+  assert(!html.includes('example'))
+
+  const escaped = adapter.codeToHtml('<script>alert("x")</script>', { lang: 'text' })
+  assert(!escaped.includes('<script>'))
+  assert(escaped.includes('&#x3C;script>'))
+
+  const fallback = adapter.codeToHtml('<img src=x onerror=alert(1)>', {
+    lang: 'missing-language',
+    meta: { __raw: '{title="untrusted"}' },
+  })
+  assert.match(fallback, /ferriki-fallback language-missing-language/)
+  assert(fallback.includes('&lt;img'))
+  assert(!fallback.includes('untrusted'))
+  assert.equal(diagnostics.length, 1)
+  assert.equal(diagnostics[0].code, 'FERRIKI_HIGHLIGHT_FALLBACK')
+  assert.match(diagnostics[0].message, /missing-language/)
+}
+finally {
+  adapter.dispose()
+}
+
+console.log('Ferriki + Ferromark + Ardo contract verified')

--- a/node/scripts/run-core-compat.mjs
+++ b/node/scripts/run-core-compat.mjs
@@ -167,6 +167,18 @@ const tokenStateCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-to
 if (tokenStateCheck.status !== 0)
   process.exit(tokenStateCheck.status || 1)
 
+const ferromarkArdoCheck = spawnSync(process.execPath, ['./scripts/check-ferromark-ardo-contract.mjs'], {
+  cwd: nodeRoot,
+  env: {
+    ...process.env,
+    FERRIKI_BACKEND: 'rust',
+    FERRIKI_HONEST_ALIAS: '1',
+  },
+  stdio: 'inherit',
+})
+if (ferromarkArdoCheck.status !== 0)
+  process.exit(ferromarkArdoCheck.status || 1)
+
 function run(args) {
   const result = spawnSync('pnpm', [...vitestArgs, ...args], {
     cwd: nodeRoot,


### PR DESCRIPTION
## Summary
- define the synchronous Ferromark 0.8 adapter boundary for Ardo
- keep light/dark rendering, line spans, and opaque `meta.__raw` handoff explicit
- add escaped plaintext fallback with one actionable diagnostic for unsupported languages
- add a runnable contract check and document ownership of titles, labels, and line metadata

No Ferromark source change is required: the existing public `codeToHtml(code, { lang, meta })` contract is sufficient.

Closes #55

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run check:ferromark-ardo`
- `node ./scripts/check-packed-consumer.mjs`
- `node ./scripts/run-core-compat.mjs`
