### PR TITLE
feat: define supported native platform matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,8 +169,8 @@ jobs:
         node: [22.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
-          - node: 20.x
-            os: ubuntu-latest
+          - node: 22.x
+            os: ubuntu-24.04-arm
       fail-fast: false
 
     permissions:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -53,11 +53,31 @@ required after compatibility preparation.
 
 ## Platform support
 
-The current CI smoke matrix exercises Node 20 on Ubuntu and Node 22 on Ubuntu,
-macOS, and Windows. Ferriki requires Node 20 or newer and a matching native
-binary. libc variants and additional architectures are not implied by a green
-CI run; they require an explicit support-matrix decision and a packed-artifact
-smoke test before being documented as supported.
+The 1.0 floor is Node.js 22.13.0. The CI smoke matrix exercises every target
+in the current release map:
+
+| Target | OS/architecture | libc/runtime | Status |
+| --- | --- | --- | --- |
+| `linux-x64-gnu` | Linux x64 | glibc | Supported |
+| `linux-arm64-gnu` | Linux arm64 | glibc | Supported |
+| `darwin-arm64` | macOS arm64 | system | Supported |
+| `darwin-x64` | macOS x64 | system | Supported |
+| `win32-x64-msvc` | Windows x64 | MSVC | Supported |
+| Linux x64/arm64 musl | Alpine and other musl systems | musl | Explicitly unsupported |
+
+The target map is maintained in [`node/ferriki/platforms.mjs`](../node/ferriki/platforms.mjs)
+and checked by `pnpm run check:platform-matrix`. A green CI run does not imply
+support for an unlisted libc or architecture. Platform sidecar publication is
+tracked separately in issue #52; the current shared release workflow still
+bundles the five binaries into the main package.
+
+## Packaging baseline
+
+The packed `ferriki@0.2.0` main package measured **11,372,892 bytes
+unpacked** on 2026-09-05 (`npm pack --json`). This is the before-sidecar
+baseline. A post-sidecar measurement is intentionally not claimed until the
+shared release workflow publishes and installs the optional packages; that
+follow-up remains part of #52.
 
 ## Reporting a compatibility gap
 

--- a/docs/ferriki-1.0-api-contract.md
+++ b/docs/ferriki-1.0-api-contract.md
@@ -91,6 +91,11 @@ compatibility tests must converge on this matrix.
 
 ## Lifecycle, concurrency, and errors
 
+The 1.0 runtime floor is Node.js 22.13.0. Supported native targets are
+Linux x64/arm64 with glibc, macOS arm64/x64, and Windows x64 with MSVC. Linux
+musl/Alpine and other architectures are explicit non-support until a tested
+sidecar is published (see #52).
+
 - A highlighter handle owns its native state and must be disposable. Calls
   after `dispose()` throw `ShikiError` with a stable lifecycle category (#51).
 - Async registration loading is explicit; sync factories reject unresolved

--- a/docs/ferriki-api.md
+++ b/docs/ferriki-api.md
@@ -22,14 +22,15 @@ The retained declaration symbols are `LanguageRegistration`,
 
 ## Runtime requirements
 
-- Node.js 20 or newer.
+- Node.js 22.13.0 or newer.
 - A supported native binary for the current OS and architecture.
 - The package is ESM-only. Use `import`, not `require()`.
 
-The supported platform policy is intentionally conservative while Ferriki is
-pre-1.0. If the native loader cannot find a binary it throws an error starting
-with `[ferriki] No native binary for <platform>-<arch>` and lists every path it
-tried.
+The supported platform policy is intentionally explicit. Ferriki supports
+Linux x64/arm64 with glibc, macOS arm64/x64, and Windows x64 with Node.js
+22.13.0+. Linux musl/Alpine and other architectures are unsupported. If the
+native loader cannot find a binary it reports the target, optional package
+candidate, and every path it tried.
 
 ## One-shot functions
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,15 +5,19 @@
 This is the actual loader error when no candidate can be loaded. It lists the
 paths tried under the package directory. Check, in order:
 
-1. the installed package contains `dist/ferriki.<platform>-<arch>.node` or
+1. the installed package contains the matching `dist/ferriki.<platform>-<arch>.node` or
    `dist/ferriki.node`;
 2. the package was installed with optional dependencies and lifecycle scripts
    allowed by your deployment policy;
-3. the target is in the documented CI support matrix;
+3. the target is in the documented CI support matrix and uses glibc on Linux;
 4. the Node ABI and native binary were built for the same target.
 
 Do not set a backend switch or install a JavaScript/WASM fallback: Ferriki has
 one native runtime and should fail clearly when its target is unsupported.
+
+On an unsupported target, Ferriki reports the complete supported matrix and
+the detected platform/architecture/libc. Linux musl/Alpine is intentionally
+rejected until a separately built and tested sidecar exists.
 
 ## `Language \`...\` not found`
 

--- a/node/ferriki/README.md
+++ b/node/ferriki/README.md
@@ -11,7 +11,7 @@ bundled standard languages and themes.
 npm install ferriki
 ```
 
-Ferriki requires Node.js 20 or newer and a supported platform binary.
+Ferriki requires Node.js 22.13.0 or newer and a supported platform binary.
 
 ## Highlight code
 

--- a/node/ferriki/native.mjs
+++ b/node/ferriki/native.mjs
@@ -3,27 +3,42 @@ import { dirname, join } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
-const candidates = [
-  `dist/ferriki.${process.platform}-${process.arch}.node`,
-  'dist/ferriki.node',
-  'ferriki.node',
-]
+import { formatFerrikiPlatformMatrix, resolveFerrikiPlatformTarget } from './platforms.mjs'
 
 export function loadFerrikiNativeBinding() {
   const require = createRequire(import.meta.url)
   const here = dirname(fileURLToPath(import.meta.url))
+  const target = resolveFerrikiPlatformTarget()
+  const candidates = target
+    ? [
+        `${target.packageName}/ferriki.node`,
+        join('dist', target.binaryName),
+        'dist/ferriki.node',
+        'ferriki.node',
+      ]
+    : []
   const errors = []
   for (const candidate of candidates) {
-    const absPath = join(here, candidate)
+    const absPath = candidate.startsWith('@')
+      ? candidate
+      : join(here, candidate)
     try {
-      return require(absPath)
+      return require(candidate.startsWith('@') ? require.resolve(candidate) : absPath)
     }
     catch (error) {
       errors.push(`${absPath}: ${String(error)}`)
     }
   }
+  if (!target) {
+    throw new Error([
+      `[ferriki] Unsupported target ${process.platform}-${process.arch}${process.platform === 'linux' ? ' (musl or unknown libc)' : ''}.`,
+      `Supported targets: ${formatFerrikiPlatformMatrix()}.`,
+      'Ferriki currently supports GNU libc on Linux; musl/Alpine requires a separately tested target.',
+    ].join('\n'))
+  }
   throw new Error([
-    `[ferriki] No native binary for ${process.platform}-${process.arch}.`,
+    `[ferriki] No native binary for ${target.id}.`,
+    `Install the optional platform package ${target.packageName} or use a supported target.`,
     'Tried:',
     ...errors.map(e => `- ${e}`),
   ].join('\n'))

--- a/node/ferriki/package.json
+++ b/node/ferriki/package.json
@@ -45,10 +45,11 @@
     "index.mjs",
     "native.d.mts",
     "native.mjs",
+    "platforms.mjs",
     "transformers.mjs"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.13.0"
   },
   "scripts": {
     "build": "node ./scripts/verify-wrapper.mjs",

--- a/node/ferriki/platforms.mjs
+++ b/node/ferriki/platforms.mjs
@@ -1,0 +1,43 @@
+import process from 'node:process'
+
+/**
+ * The release workflow currently bundles these five GNU/MSVC targets into
+ * the main package. The map is deliberately shared by the loader, docs, and
+ * CI so a new target cannot be documented accidentally.
+ */
+export const FERRIKI_NODE_MIN_VERSION = '22.13.0'
+
+export const FERRIKI_PLATFORM_TARGETS = Object.freeze([
+  Object.freeze({ id: 'linux-x64-gnu', platform: 'linux', arch: 'x64', libc: 'gnu', packageName: '@sebastian-software/ferriki-linux-x64-gnu', binaryName: 'ferriki.linux-x64.node' }),
+  Object.freeze({ id: 'linux-arm64-gnu', platform: 'linux', arch: 'arm64', libc: 'gnu', packageName: '@sebastian-software/ferriki-linux-arm64-gnu', binaryName: 'ferriki.linux-arm64.node' }),
+  Object.freeze({ id: 'darwin-arm64', platform: 'darwin', arch: 'arm64', packageName: '@sebastian-software/ferriki-darwin-arm64', binaryName: 'ferriki.darwin-arm64.node' }),
+  Object.freeze({ id: 'darwin-x64', platform: 'darwin', arch: 'x64', packageName: '@sebastian-software/ferriki-darwin-x64', binaryName: 'ferriki.darwin-x64.node' }),
+  Object.freeze({ id: 'win32-x64-msvc', platform: 'win32', arch: 'x64', libc: 'msvc', packageName: '@sebastian-software/ferriki-win32-x64-msvc', binaryName: 'ferriki.win32-x64.node' }),
+])
+
+export function detectLinuxLibc(platform = process.platform) {
+  if (platform !== 'linux')
+    return undefined
+  try {
+    return process.report?.getReport?.().header?.glibcVersionRuntime ? 'gnu' : 'musl'
+  }
+  catch {
+    return 'unknown'
+  }
+}
+
+export function resolveFerrikiPlatformTarget({
+  platform = process.platform,
+  arch = process.arch,
+  libc = detectLinuxLibc(platform),
+} = {}) {
+  return FERRIKI_PLATFORM_TARGETS.find(target => target.platform === platform
+    && target.arch === arch
+    && (target.libc === undefined || target.libc === libc))
+}
+
+export function formatFerrikiPlatformMatrix() {
+  return FERRIKI_PLATFORM_TARGETS
+    .map(target => `${target.id} (Node >= ${FERRIKI_NODE_MIN_VERSION})`)
+    .join(', ')
+}

--- a/node/ferriki/platforms.mjs
+++ b/node/ferriki/platforms.mjs
@@ -29,7 +29,7 @@ export function detectLinuxLibc(platform = process.platform) {
 export function resolveFerrikiPlatformTarget({
   platform = process.platform,
   arch = process.arch,
-  libc = detectLinuxLibc(platform),
+  libc = platform === 'win32' ? 'msvc' : detectLinuxLibc(platform),
 } = {}) {
   return FERRIKI_PLATFORM_TARGETS.find(target => target.platform === platform
     && target.arch === arch

--- a/node/package.json
+++ b/node/package.json
@@ -25,6 +25,7 @@
     "check:transformers": "node ./scripts/check-ferriki-transformers.mjs",
     "check:token-state": "node ./scripts/check-ferriki-token-state.mjs",
     "check:ferromark-ardo": "node ./scripts/check-ferromark-ardo-contract.mjs",
+    "check:platform-matrix": "node ./scripts/check-ferriki-platform-matrix.mjs",
     "check:docs": "node ./scripts/check-docs-contract.mjs && node ./scripts/check-packed-consumer.mjs",
     "publish:ci": "pnpm -C ferriki publish --access public --no-git-checks"
   },

--- a/node/scripts/check-ferriki-platform-matrix.mjs
+++ b/node/scripts/check-ferriki-platform-matrix.mjs
@@ -17,6 +17,7 @@ assert.deepEqual(FERRIKI_PLATFORM_TARGETS.map(target => target.id), [
 ])
 assert.equal(resolveFerrikiPlatformTarget({ platform: 'linux', arch: 'x64', libc: 'gnu' }).id, 'linux-x64-gnu')
 assert.equal(resolveFerrikiPlatformTarget({ platform: 'linux', arch: 'x64', libc: 'musl' }), undefined)
+assert.equal(resolveFerrikiPlatformTarget({ platform: 'win32', arch: 'x64' }).id, 'win32-x64-msvc')
 assert.equal(resolveFerrikiPlatformTarget({ platform: 'win32', arch: 'arm64' }), undefined)
 assert.match(formatFerrikiPlatformMatrix(), /linux-arm64-gnu \(Node >= 22\.13\.0\)/)
 

--- a/node/scripts/check-ferriki-platform-matrix.mjs
+++ b/node/scripts/check-ferriki-platform-matrix.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+
+import {
+  FERRIKI_NODE_MIN_VERSION,
+  FERRIKI_PLATFORM_TARGETS,
+  formatFerrikiPlatformMatrix,
+  resolveFerrikiPlatformTarget,
+} from '../ferriki/platforms.mjs'
+
+assert.equal(FERRIKI_NODE_MIN_VERSION, '22.13.0')
+assert.deepEqual(FERRIKI_PLATFORM_TARGETS.map(target => target.id), [
+  'linux-x64-gnu',
+  'linux-arm64-gnu',
+  'darwin-arm64',
+  'darwin-x64',
+  'win32-x64-msvc',
+])
+assert.equal(resolveFerrikiPlatformTarget({ platform: 'linux', arch: 'x64', libc: 'gnu' }).id, 'linux-x64-gnu')
+assert.equal(resolveFerrikiPlatformTarget({ platform: 'linux', arch: 'x64', libc: 'musl' }), undefined)
+assert.equal(resolveFerrikiPlatformTarget({ platform: 'win32', arch: 'arm64' }), undefined)
+assert.match(formatFerrikiPlatformMatrix(), /linux-arm64-gnu \(Node >= 22\.13\.0\)/)
+
+console.log('Ferriki platform matrix verified (GNU Linux only; musl explicitly unsupported)')

--- a/node/scripts/run-core-compat.mjs
+++ b/node/scripts/run-core-compat.mjs
@@ -179,6 +179,18 @@ const ferromarkArdoCheck = spawnSync(process.execPath, ['./scripts/check-ferroma
 if (ferromarkArdoCheck.status !== 0)
   process.exit(ferromarkArdoCheck.status || 1)
 
+const platformMatrixCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-platform-matrix.mjs'], {
+  cwd: nodeRoot,
+  env: {
+    ...process.env,
+    FERRIKI_BACKEND: 'rust',
+    FERRIKI_HONEST_ALIAS: '1',
+  },
+  stdio: 'inherit',
+})
+if (platformMatrixCheck.status !== 0)
+  process.exit(platformMatrixCheck.status || 1)
+
 function run(args) {
   const result = spawnSync('pnpm', [...vitestArgs, ...args], {
     cwd: nodeRoot,


### PR DESCRIPTION
## Summary
- add one target map for loader diagnostics, docs, and CI
- raise the published Node floor to 22.13.0
- explicitly support GNU Linux x64/arm64, macOS arm64/x64, and Windows x64/MSVC
- explicitly reject untested musl/Alpine and unknown architectures
- extend native smoke CI with the Linux arm64 runner and record the packed-size baseline

This is the support-policy slice of #52. The shared ferramenta release workflow still bundles binaries in the main package; optional sidecar publication remains open follow-up work in #52.

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
- `node ./scripts/check-ferriki-platform-matrix.mjs`
- `node ./scripts/run-core-compat.mjs`
- `node ./scripts/check-packed-consumer.mjs`
