### PR TITLE
fix: restore full bundle compatibility gate

### DIFF
--- a/crates/ferriki-textmate/src/raw_grammar.rs
+++ b/crates/ferriki-textmate/src/raw_grammar.rs
@@ -28,7 +28,7 @@ pub type RawCaptures = BTreeMap<String, Arc<RawRule>>;
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RawGrammar {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_raw_repository")]
     pub repository: RawRepository,
     pub scope_name: String,
     #[serde(default)]
@@ -96,7 +96,11 @@ pub struct RawRule {
     pub while_captures: Option<RawCaptures>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub patterns: Option<Vec<Arc<RawRule>>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_raw_repository",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub repository: Option<RawRepository>,
     #[serde(default, deserialize_with = "deserialize_bool_like")]
     pub apply_end_pattern_last: bool,
@@ -158,20 +162,87 @@ fn deserialize_optional_raw_rule_map<'de, D>(
 where
     D: Deserializer<'de>,
 {
-    let values = Option::<BTreeMap<String, serde_json::Value>>::deserialize(deserializer)?;
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    let Some(value) = value else { return Ok(None) };
+
+    let values: Vec<(String, serde_json::Value)> = match value {
+        serde_json::Value::Object(values) => values.into_iter().collect(),
+        serde_json::Value::Array(values) => values
+            .into_iter()
+            .enumerate()
+            .map(|(index, value)| (index.to_string(), value))
+            .collect(),
+        value => {
+            return Err(de::Error::custom(format!(
+                "expected capture map or array, got {value}"
+            )))
+        }
+    };
+
     values
+        .into_iter()
+        .filter_map(|(key, value)| value.is_object().then_some((key, value)))
+        .map(|(key, value)| {
+            serde_json::from_value(value)
+                .map(|rule| (key, Arc::new(rule)))
+                .map_err(de::Error::custom)
+        })
+        .collect::<Result<RawCaptures, _>>()
+        .map(Some)
+}
+
+fn deserialize_raw_repository<'de, D>(deserializer: D) -> Result<RawRepository, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let values = BTreeMap::<String, serde_json::Value>::deserialize(deserializer)?;
+    values
+        .into_iter()
+        .map(|(key, value)| deserialize_repository_entry(key, value).map_err(de::Error::custom))
+        .collect()
+}
+
+fn deserialize_optional_raw_repository<'de, D>(
+    deserializer: D,
+) -> Result<Option<RawRepository>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<BTreeMap<String, serde_json::Value>>::deserialize(deserializer)?
         .map(|values| {
             values
                 .into_iter()
-                .filter_map(|(key, value)| value.is_object().then_some((key, value)))
                 .map(|(key, value)| {
-                    serde_json::from_value(value)
-                        .map(|rule| (key, Arc::new(rule)))
-                        .map_err(de::Error::custom)
+                    deserialize_repository_entry(key, value).map_err(de::Error::custom)
                 })
                 .collect()
         })
         .transpose()
+}
+
+fn deserialize_repository_entry(
+    key: String,
+    value: serde_json::Value,
+) -> Result<(String, Arc<RawRule>), serde_json::Error> {
+    let rule = match value {
+        serde_json::Value::Object(_) => serde_json::from_value(value)?,
+        serde_json::Value::Array(values) => RawRule {
+            patterns: Some(
+                values
+                    .into_iter()
+                    .map(serde_json::from_value)
+                    .collect::<Result<Vec<Arc<RawRule>>, _>>()?,
+            ),
+            ..RawRule::default()
+        },
+        value => {
+            return Err(serde_json::Error::io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("repository entry {key} must be an object or array, got {value}"),
+            )))
+        }
+    };
+    Ok((key, Arc::new(rule)))
 }
 
 #[cfg(test)]
@@ -303,5 +374,58 @@ mod tests {
             captures["0"].name.as_deref(),
             Some("punctuation.definition.comment")
         );
+    }
+
+    #[test]
+    fn accepts_legacy_capture_arrays() {
+        let grammar: RawGrammar = serde_json::from_str(
+            r#"{
+                "scopeName": "source.test",
+                "patterns": [{
+                    "match": "x",
+                    "captures": [
+                        { "name": "punctuation.definition.begin" },
+                        null,
+                        { "name": "punctuation.definition.end" }
+                    ]
+                }]
+            }"#,
+        )
+        .unwrap();
+
+        let captures = grammar.patterns[0].captures.as_ref().unwrap();
+        assert_eq!(
+            captures["0"].name.as_deref(),
+            Some("punctuation.definition.begin")
+        );
+        assert!(!captures.contains_key("1"));
+        assert_eq!(
+            captures["2"].name.as_deref(),
+            Some("punctuation.definition.end")
+        );
+    }
+
+    #[test]
+    fn accepts_repository_rule_arrays() {
+        let grammar: RawGrammar = serde_json::from_str(
+            r#"{
+                "scopeName": "source.test",
+                "repository": {
+                    "alternatives": [
+                        { "match": "a", "name": "keyword.a" },
+                        { "match": "b", "name": "keyword.b" }
+                    ]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let alternatives = grammar.repository["alternatives"]
+            .patterns
+            .as_ref()
+            .unwrap();
+        assert_eq!(alternatives.len(), 2);
+        assert_eq!(alternatives[0].name.as_deref(), Some("keyword.a"));
+        assert_eq!(alternatives[1].name.as_deref(), Some("keyword.b"));
     }
 }

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -51,6 +51,13 @@ the package manifest and source tree against legacy runtime dependencies,
 fallback loaders, and forbidden runtime files. A clean working tree is
 required after compatibility preparation.
 
+The core gate also runs Shiki's `bundle-full` and `bundle-web` smoke tests. The
+current pinned baseline expects 364 and 96 loaded languages respectively. The
+audit found two grammar-shape gaps that had been hidden by the old exclusion:
+legacy capture arrays (for example, `jinja`) and repository entries represented
+as rule arrays (for example, `racket`). Ferriki normalizes both forms at the
+raw-grammar boundary, with focused Rust tests covering the conversion.
+
 ## Platform support
 
 The 1.0 floor is Node.js 22.13.0. The CI smoke matrix exercises every target

--- a/node/compat/harness/core-compat-manifest.mjs
+++ b/node/compat/harness/core-compat-manifest.mjs
@@ -4,6 +4,7 @@ export const coreCompatSupportedTests = [
   'compat/upstream/shiki/packages/core/test/get-singleton.test.ts',
   'compat/upstream/shiki/packages/shiki/test/alias.test.ts',
   'compat/upstream/shiki/packages/shiki/test/astro.test.ts',
+  'compat/upstream/shiki/packages/shiki/test/bundle.test.ts',
   'compat/upstream/shiki/packages/shiki/test/get-highlighter.test.ts',
   'compat/upstream/shiki/packages/shiki/test/general.test.ts',
   'compat/upstream/shiki/packages/shiki/test/injections.test.ts',

--- a/node/package.json
+++ b/node/package.json
@@ -16,7 +16,7 @@
     "test:ferriki-compat": "pnpm run test:ferriki-compat:core",
     "test:ferriki-compat:textmate": "FERRIKI_HONEST_ALIAS=1 vitest run compat/upstream/shiki/packages/core/test/core.test.ts compat/upstream/shiki/packages/shiki/test/injections.test.ts compat/upstream/shiki/packages/shiki/test/general.test.ts -t '^(should|vue-injections|injections-side-effects)' --maxWorkers 1 --no-file-parallelism",
     "test:ferriki-compat:core": "pnpm run build:compat && pnpm -C ferriki build:native && node ./scripts/run-core-compat.mjs",
-    "test:ferriki-compat:core:full": "pnpm run build:compat && pnpm -C ferriki build:native && FERRIKI_HONEST_ALIAS=1 FERRIKI_BACKEND=rust vitest compat/upstream/shiki/packages/core/test compat/upstream/shiki/packages/shiki/test --exclude compat/upstream/shiki/packages/shiki/test/bundle.test.ts --run --maxWorkers 1 --no-file-parallelism",
+    "test:ferriki-compat:core:full": "pnpm run build:compat && pnpm -C ferriki build:native && FERRIKI_HONEST_ALIAS=1 FERRIKI_BACKEND=rust vitest compat/upstream/shiki/packages/core/test compat/upstream/shiki/packages/shiki/test --run --maxWorkers 1 --no-file-parallelism",
     "test:ferriki-compat:adapters": "pnpm run build:compat && pnpm -C ferriki build:native && FERRIKI_BACKEND=rust vitest compat/upstream/shiki/packages/transformers/test compat/upstream/shiki/packages/twoslash/test --exclude compat/upstream/shiki/packages/twoslash/test/markdown-it.test.ts --run --maxWorkers 1 --no-file-parallelism",
     "test:ferriki-compat:colorized-brackets": "pnpm run build:compat && pnpm -C ferriki build:native && node ./compat/harness/run-colorized-brackets-compat.mjs",
     "check:errors": "node ./scripts/check-ferriki-errors.mjs",

--- a/node/scripts/run-core-compat.mjs
+++ b/node/scripts/run-core-compat.mjs
@@ -9,7 +9,7 @@ const vitestArgs = [
   'exec',
   'vitest',
 ]
-const testNamePattern = '^(should|langAlias|getSingletonHighlighter|vue-injections|injections-side-effects)'
+const testNamePattern = '^(should|langAlias|getSingletonHighlighter|vue-injections|injections-side-effects|bundle-(full|web))'
 
 const catalogCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-catalog.mjs'], {
   cwd: nodeRoot,
@@ -217,8 +217,6 @@ run([
 run([
   'run',
   ...coreCompatSupportedTests,
-  '--exclude',
-  'compat/upstream/shiki/packages/shiki/test/bundle.test.ts',
   '-t',
   testNamePattern,
   '--maxWorkers',


### PR DESCRIPTION
## Summary
- accept legacy capture arrays used by grammars such as `jinja`
- normalize repository rule arrays used by grammars such as `racket`
- re-enable Shiki `bundle-full` (364) and `bundle-web` (96) in the mandatory core gate
- document the reproduced grammar-shape gaps and pinned counts

## Validation
- `cargo test --workspace`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `node ./scripts/run-core-compat.mjs`
- packed consumer smoke

Fixes #12