### PR TITLE
ci: build native addons for explicit targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,11 +166,27 @@ jobs:
 
     strategy:
       matrix:
-        node: [22.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - node: 22.x
+            os: ubuntu-latest
+            rust-target: x86_64-unknown-linux-gnu
+            platform-target: linux-x64
+          - node: 22.x
             os: ubuntu-24.04-arm
+            rust-target: aarch64-unknown-linux-gnu
+            platform-target: linux-arm64
+          - node: 22.x
+            os: macos-latest
+            rust-target: aarch64-apple-darwin
+            platform-target: darwin-arm64
+          - node: 22.x
+            os: macos-15-intel
+            rust-target: x86_64-apple-darwin
+            platform-target: darwin-x64
+          - node: 22.x
+            os: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            platform-target: win32-x64
       fail-fast: false
 
     permissions:
@@ -178,6 +194,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Set Rust target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v3
@@ -197,6 +218,9 @@ jobs:
 
       - name: Build native
         run: pnpm run build:native
+        env:
+          FERRIKI_RUST_TARGET: ${{ matrix.rust-target }}
+          FERRIKI_PLATFORM_TARGET: ${{ matrix.platform-target }}
 
       - name: Verify packed consumer on the target platform
         run: node ./scripts/check-packed-consumer.mjs

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -78,6 +78,10 @@ support for an unlisted libc or architecture. Platform sidecar publication is
 tracked separately in issue #52; the current shared release workflow still
 bundles the five binaries into the main package.
 
+The native smoke jobs build with an explicit Rust target for each supported
+platform, including macOS Intel (`x86_64-apple-darwin`). This catches a host
+versus target mismatch before release artifacts are assembled.
+
 ## Packaging baseline
 
 The packed `ferriki@0.2.0` main package measured **11,372,892 bytes

--- a/node/ferriki/scripts/build-native.mjs
+++ b/node/ferriki/scripts/build-native.mjs
@@ -10,13 +10,20 @@ const manifestPath = join(repoRoot, 'crates', 'ferriki-core', 'Cargo.toml')
 const addonOut = join(pkgDir, 'ferriki.node')
 const distAddonOut = join(pkgDir, 'dist', 'ferriki.node')
 const rustTarget = process.env.FERRIKI_RUST_TARGET
-const platformTarget = process.env.FERRIKI_PLATFORM_TARGET ?? (rustTarget ? {
-  'x86_64-unknown-linux-gnu': 'linux-x64',
-  'aarch64-unknown-linux-gnu': 'linux-arm64',
-  'aarch64-apple-darwin': 'darwin-arm64',
-  'x86_64-apple-darwin': 'darwin-x64',
-  'x86_64-pc-windows-msvc': 'win32-x64',
-}[rustTarget] : `${process.platform}-${process.arch}`)
+let platformTarget = process.env.FERRIKI_PLATFORM_TARGET
+
+if (!platformTarget && rustTarget) {
+  platformTarget = {
+    'x86_64-unknown-linux-gnu': 'linux-x64',
+    'aarch64-unknown-linux-gnu': 'linux-arm64',
+    'aarch64-apple-darwin': 'darwin-arm64',
+    'x86_64-apple-darwin': 'darwin-x64',
+    'x86_64-pc-windows-msvc': 'win32-x64',
+  }[rustTarget]
+}
+
+if (!platformTarget)
+  platformTarget = `${process.platform}-${process.arch}`
 
 if (!platformTarget) {
   throw new Error(`[ferriki] Unsupported FERRIKI_RUST_TARGET: ${rustTarget}`)

--- a/node/ferriki/scripts/build-native.mjs
+++ b/node/ferriki/scripts/build-native.mjs
@@ -9,10 +9,27 @@ const repoRoot = join(pkgDir, '..', '..')
 const manifestPath = join(repoRoot, 'crates', 'ferriki-core', 'Cargo.toml')
 const addonOut = join(pkgDir, 'ferriki.node')
 const distAddonOut = join(pkgDir, 'dist', 'ferriki.node')
-const platformAddonOut = join(pkgDir, 'dist', `ferriki.${process.platform}-${process.arch}.node`)
-const syncAssetsScript = join(pkgDir, 'scripts', 'sync-standard-assets.mjs')
+const rustTarget = process.env.FERRIKI_RUST_TARGET
+const platformTarget = process.env.FERRIKI_PLATFORM_TARGET ?? (rustTarget ? {
+  'x86_64-unknown-linux-gnu': 'linux-x64',
+  'aarch64-unknown-linux-gnu': 'linux-arm64',
+  'aarch64-apple-darwin': 'darwin-arm64',
+  'x86_64-apple-darwin': 'darwin-x64',
+  'x86_64-pc-windows-msvc': 'win32-x64',
+}[rustTarget] : `${process.platform}-${process.arch}`)
 
-const cargo = spawnSync('cargo', ['build', '--release', '--manifest-path', manifestPath], {
+if (!platformTarget) {
+  throw new Error(`[ferriki] Unsupported FERRIKI_RUST_TARGET: ${rustTarget}`)
+}
+
+const platformAddonOut = join(pkgDir, 'dist', `ferriki.${platformTarget}.node`)
+const syncAssetsScript = join(pkgDir, 'scripts', 'sync-standard-assets.mjs')
+const cargoArgs = ['build', '--release', '--manifest-path', manifestPath]
+
+if (rustTarget)
+  cargoArgs.push('--target', rustTarget)
+
+const cargo = spawnSync('cargo', cargoArgs, {
   cwd: repoRoot,
   stdio: 'inherit',
 })
@@ -27,7 +44,7 @@ const dylibName = process.platform === 'darwin'
     : 'ferriki_core.dll'
 
 const candidates = [
-  join(repoRoot, 'target', 'release', dylibName),
+  join(repoRoot, 'target', ...(rustTarget ? [rustTarget] : []), 'release', dylibName),
 ]
 
 let selectedInput = null


### PR DESCRIPTION
## Summary
- make Ferriki's native builder accept an explicit Rust target and resolve the corresponding platform binary name
- run native smoke coverage on the documented five-target matrix, including macOS Intel
- install the requested Rust target before building and document the host/target mismatch guard

## Validation
- `cargo check -p ferriki-core`
- `pnpm run build:native`
- `FERRIKI_RUST_TARGET=x86_64-apple-darwin FERRIKI_PLATFORM_TARGET=darwin-x64 pnpm run build:native`
- `node ./scripts/check-packed-consumer.mjs`
- `pnpm run lint`
- local ARM build restored after cross-target verification

Related to #52
Related to #54
