### PR TITLE
feat: add native platform sidecar packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,22 +174,27 @@ jobs:
             os: ubuntu-latest
             rust-target: x86_64-unknown-linux-gnu
             platform-target: linux-x64
+            platform-id: linux-x64-gnu
           - node: 22.x
             os: ubuntu-24.04-arm
             rust-target: aarch64-unknown-linux-gnu
             platform-target: linux-arm64
+            platform-id: linux-arm64-gnu
           - node: 22.x
             os: macos-latest
             rust-target: aarch64-apple-darwin
             platform-target: darwin-arm64
+            platform-id: darwin-arm64
           - node: 22.x
             os: macos-15-intel
             rust-target: x86_64-apple-darwin
             platform-target: darwin-x64
+            platform-id: darwin-x64
           - node: 22.x
             os: windows-latest
             rust-target: x86_64-pc-windows-msvc
             platform-target: win32-x64
+            platform-id: win32-x64-msvc
       fail-fast: false
 
     permissions:
@@ -224,6 +229,12 @@ jobs:
         env:
           FERRIKI_RUST_TARGET: ${{ matrix.rust-target }}
           FERRIKI_PLATFORM_TARGET: ${{ matrix.platform-target }}
+          FERRIKI_PLATFORM_ID: ${{ matrix.platform-id }}
+
+      - name: Verify native platform package
+        run: nr check:platform-package
+        env:
+          FERRIKI_PLATFORM_ID: ${{ matrix.platform-id }}
 
       - name: Verify packed consumer on the target platform
         run: node ./scripts/check-packed-consumer.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ dist
 # Native addon artifacts (rebuilt by build:native)
 node/ferriki/*.node
 node/ferriki/assets/
+node/platforms/*/ferriki.node
 
 # Generated inside the upstream mirror (prepare scripts at install time)
 node/compat/upstream/shiki/packages/colorized-brackets/src/themes.ts

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -75,8 +75,9 @@ in the current release map:
 The target map is maintained in [`node/ferriki/platforms.mjs`](../node/ferriki/platforms.mjs)
 and checked by `pnpm run check:platform-matrix`. A green CI run does not imply
 support for an unlisted libc or architecture. Platform sidecar publication is
-tracked separately in issue #52; the current shared release workflow still
-bundles the five binaries into the main package.
+tracked separately in issue #52. The five sidecar manifests now live under
+`node/platforms/*` and are declared as optional dependencies; publication and
+artifact assembly remain part of the release workflow work in #54.
 
 The native smoke jobs build with an explicit Rust target for each supported
 platform, including macOS Intel (`x86_64-apple-darwin`). This catches a host
@@ -87,8 +88,8 @@ versus target mismatch before release artifacts are assembled.
 The packed `ferriki@0.2.0` main package measured **11,372,892 bytes
 unpacked** on 2026-09-05 (`npm pack --json`). This is the before-sidecar
 baseline. A post-sidecar measurement is intentionally not claimed until the
-shared release workflow publishes and installs the optional packages; that
-follow-up remains part of #52.
+release workflow publishes and installs the optional packages; that follow-up
+remains part of #52/#54.
 
 ## Reporting a compatibility gap
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,8 +5,8 @@
 This is the actual loader error when no candidate can be loaded. It lists the
 paths tried under the package directory. Check, in order:
 
-1. the installed package contains the matching `dist/ferriki.<platform>-<arch>.node` or
-   `dist/ferriki.node`;
+1. the matching optional package (`@sebastian-software/ferriki-*`) is installed,
+   or the main package contains `dist/ferriki.<platform>-<arch>.node`;
 2. the package was installed with optional dependencies and lifecycle scripts
    allowed by your deployment policy;
 3. the target is in the documented CI support matrix and uses glibc on Linux;

--- a/node/ferriki/README.md
+++ b/node/ferriki/README.md
@@ -12,6 +12,10 @@ npm install ferriki
 ```
 
 Ferriki requires Node.js 22.13.0 or newer and a supported platform binary.
+The main package declares one optional native package for each supported target;
+package managers select the matching OS/CPU/libc sidecar automatically. Keep
+optional dependencies enabled in production installs unless you intentionally
+ship the bundled main-package binary instead.
 
 ## Highlight code
 

--- a/node/ferriki/package.json
+++ b/node/ferriki/package.json
@@ -58,6 +58,13 @@
     "dev": "node ./scripts/build-wrapper.mjs && node ./scripts/verify-wrapper.mjs",
     "build:native": "node ./scripts/build-native.mjs"
   },
+  "optionalDependencies": {
+    "@sebastian-software/ferriki-darwin-arm64": "0.2.0",
+    "@sebastian-software/ferriki-darwin-x64": "0.2.0",
+    "@sebastian-software/ferriki-linux-arm64-gnu": "0.2.0",
+    "@sebastian-software/ferriki-linux-x64-gnu": "0.2.0",
+    "@sebastian-software/ferriki-win32-x64-msvc": "0.2.0"
+  },
   "devDependencies": {
     "@types/node": "catalog:types"
   }

--- a/node/ferriki/scripts/build-native.mjs
+++ b/node/ferriki/scripts/build-native.mjs
@@ -11,6 +11,17 @@ const addonOut = join(pkgDir, 'ferriki.node')
 const distAddonOut = join(pkgDir, 'dist', 'ferriki.node')
 const rustTarget = process.env.FERRIKI_RUST_TARGET
 let platformTarget = process.env.FERRIKI_PLATFORM_TARGET
+let platformId = process.env.FERRIKI_PLATFORM_ID
+
+if (!platformId && rustTarget) {
+  platformId = {
+    'x86_64-unknown-linux-gnu': 'linux-x64-gnu',
+    'aarch64-unknown-linux-gnu': 'linux-arm64-gnu',
+    'aarch64-apple-darwin': 'darwin-arm64',
+    'x86_64-apple-darwin': 'darwin-x64',
+    'x86_64-pc-windows-msvc': 'win32-x64-msvc',
+  }[rustTarget]
+}
 
 if (!platformTarget && rustTarget) {
   platformTarget = {
@@ -30,6 +41,9 @@ if (!platformTarget) {
 }
 
 const platformAddonOut = join(pkgDir, 'dist', `ferriki.${platformTarget}.node`)
+const sidecarAddonOut = platformId
+  ? join(repoRoot, 'node', 'platforms', platformId, 'ferriki.node')
+  : undefined
 const syncAssetsScript = join(pkgDir, 'scripts', 'sync-standard-assets.mjs')
 const cargoArgs = ['build', '--release', '--manifest-path', manifestPath]
 
@@ -79,6 +93,8 @@ if (!selectedInput) {
 await cp(selectedInput, addonOut)
 await cp(selectedInput, distAddonOut)
 await cp(selectedInput, platformAddonOut)
+if (sidecarAddonOut)
+  await cp(selectedInput, sidecarAddonOut)
 const syncAssets = spawnSync('node', [syncAssetsScript], {
   cwd: repoRoot,
   stdio: 'inherit',
@@ -90,3 +106,5 @@ if (syncAssets.status !== 0)
 console.log(`[ferriki] Native addon ready: ${addonOut}`)
 console.log(`[ferriki] Bundled native addon ready: ${distAddonOut}`)
 console.log(`[ferriki] Platform addon ready: ${platformAddonOut}`)
+if (sidecarAddonOut)
+  console.log(`[ferriki] Sidecar addon ready: ${sidecarAddonOut}`)

--- a/node/package.json
+++ b/node/package.json
@@ -20,6 +20,7 @@
     "test:ferriki-compat:adapters": "pnpm run build:compat && pnpm -C ferriki build:native && FERRIKI_BACKEND=rust vitest compat/upstream/shiki/packages/transformers/test compat/upstream/shiki/packages/twoslash/test --exclude compat/upstream/shiki/packages/twoslash/test/markdown-it.test.ts --run --maxWorkers 1 --no-file-parallelism",
     "test:ferriki-compat:colorized-brackets": "pnpm run build:compat && pnpm -C ferriki build:native && node ./compat/harness/run-colorized-brackets-compat.mjs",
     "check:errors": "node ./scripts/check-ferriki-errors.mjs",
+    "check:platform-package": "node ./scripts/check-platform-package.mjs",
     "check:api": "node ./scripts/check-generated-api.mjs",
     "check:boundary": "node ./scripts/check-native-boundary.mjs",
     "check:release": "node ./scripts/check-release-workflow.mjs",

--- a/node/platforms/darwin-arm64/package.json
+++ b/node/platforms/darwin-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sebastian-software/ferriki-darwin-arm64",
+  "version": "0.2.0",
+  "description": "Ferriki native addon for macOS arm64",
+  "license": "MIT",
+  "repository": "git+https://github.com/sebastian-software/ferriki.git",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "ferriki.node",
+  "files": [
+    "ferriki.node"
+  ],
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/node/platforms/darwin-x64/package.json
+++ b/node/platforms/darwin-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sebastian-software/ferriki-darwin-x64",
+  "version": "0.2.0",
+  "description": "Ferriki native addon for macOS x64",
+  "license": "MIT",
+  "repository": "git+https://github.com/sebastian-software/ferriki.git",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "ferriki.node",
+  "files": [
+    "ferriki.node"
+  ],
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/node/platforms/linux-arm64-gnu/package.json
+++ b/node/platforms/linux-arm64-gnu/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@sebastian-software/ferriki-linux-arm64-gnu",
+  "version": "0.2.0",
+  "description": "Ferriki native addon for Linux arm64 with GNU libc",
+  "license": "MIT",
+  "repository": "git+https://github.com/sebastian-software/ferriki.git",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "main": "ferriki.node",
+  "files": [
+    "ferriki.node"
+  ],
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/node/platforms/linux-x64-gnu/package.json
+++ b/node/platforms/linux-x64-gnu/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@sebastian-software/ferriki-linux-x64-gnu",
+  "version": "0.2.0",
+  "description": "Ferriki native addon for Linux x64 with GNU libc",
+  "license": "MIT",
+  "repository": "git+https://github.com/sebastian-software/ferriki.git",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "main": "ferriki.node",
+  "files": [
+    "ferriki.node"
+  ],
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/node/platforms/win32-x64-msvc/package.json
+++ b/node/platforms/win32-x64-msvc/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sebastian-software/ferriki-win32-x64-msvc",
+  "version": "0.2.0",
+  "description": "Ferriki native addon for Windows x64 with MSVC",
+  "license": "MIT",
+  "repository": "git+https://github.com/sebastian-software/ferriki.git",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "ferriki.node",
+  "files": [
+    "ferriki.node"
+  ],
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/node/pnpm-lock.yaml
+++ b/node/pnpm-lock.yaml
@@ -555,6 +555,32 @@ importers:
       '@types/node':
         specifier: catalog:types
         version: 25.3.3
+    optionalDependencies:
+      '@sebastian-software/ferriki-darwin-arm64':
+        specifier: 0.2.0
+        version: link:../platforms/darwin-arm64
+      '@sebastian-software/ferriki-darwin-x64':
+        specifier: 0.2.0
+        version: link:../platforms/darwin-x64
+      '@sebastian-software/ferriki-linux-arm64-gnu':
+        specifier: 0.2.0
+        version: link:../platforms/linux-arm64-gnu
+      '@sebastian-software/ferriki-linux-x64-gnu':
+        specifier: 0.2.0
+        version: link:../platforms/linux-x64-gnu
+      '@sebastian-software/ferriki-win32-x64-msvc':
+        specifier: 0.2.0
+        version: link:../platforms/win32-x64-msvc
+
+  platforms/darwin-arm64: {}
+
+  platforms/darwin-x64: {}
+
+  platforms/linux-arm64-gnu: {}
+
+  platforms/linux-x64-gnu: {}
+
+  platforms/win32-x64-msvc: {}
 
 packages:
 

--- a/node/pnpm-workspace.yaml
+++ b/node/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ trustPolicy: no-downgrade
 
 packages:
   - ferriki
+  - platforms/*
   - compat/upstream/shiki/packages/*
 catalogs:
   bundling:

--- a/node/scripts/check-ferriki-platform-matrix.mjs
+++ b/node/scripts/check-ferriki-platform-matrix.mjs
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import {
   FERRIKI_NODE_MIN_VERSION,
@@ -6,6 +9,9 @@ import {
   formatFerrikiPlatformMatrix,
   resolveFerrikiPlatformTarget,
 } from '../ferriki/platforms.mjs'
+
+const nodeRoot = join(fileURLToPath(new URL('.', import.meta.url)), '..')
+const ferrikiManifest = JSON.parse(await readFile(join(nodeRoot, 'ferriki', 'package.json'), 'utf8'))
 
 assert.equal(FERRIKI_NODE_MIN_VERSION, '22.13.0')
 assert.deepEqual(FERRIKI_PLATFORM_TARGETS.map(target => target.id), [
@@ -20,5 +26,16 @@ assert.equal(resolveFerrikiPlatformTarget({ platform: 'linux', arch: 'x64', libc
 assert.equal(resolveFerrikiPlatformTarget({ platform: 'win32', arch: 'x64' }).id, 'win32-x64-msvc')
 assert.equal(resolveFerrikiPlatformTarget({ platform: 'win32', arch: 'arm64' }), undefined)
 assert.match(formatFerrikiPlatformMatrix(), /linux-arm64-gnu \(Node >= 22\.13\.0\)/)
+
+for (const target of FERRIKI_PLATFORM_TARGETS) {
+  assert.equal(
+    ferrikiManifest.optionalDependencies?.[target.packageName],
+    ferrikiManifest.version,
+    `${target.id} must be declared as an optional dependency at the package version`,
+  )
+  const sidecar = JSON.parse(await readFile(join(nodeRoot, 'platforms', target.id, 'package.json'), 'utf8'))
+  assert.equal(sidecar.name, target.packageName)
+  assert(sidecar.files.includes('ferriki.node'), `${target.id} sidecar must publish ferriki.node`)
+}
 
 console.log('Ferriki platform matrix verified (GNU Linux only; musl explicitly unsupported)')

--- a/node/scripts/check-packed-consumer.mjs
+++ b/node/scripts/check-packed-consumer.mjs
@@ -52,7 +52,9 @@ try {
   const tarball = join(tempRoot, metadata.filename)
   const consumer = await mkdtemp(join(tempRoot, 'consumer-'))
   run(npmCommand, ['init', '--yes'], { cwd: consumer, stdio: 'ignore' })
-  run(npmCommand, ['install', '--ignore-scripts', '--no-audit', '--no-fund', tarball], { cwd: consumer, stdio: 'ignore' })
+  // Sidecars are published independently. The main-package smoke intentionally
+  // omits them so this gate remains runnable before the first coordinated npm release.
+  run(npmCommand, ['install', '--ignore-scripts', '--omit=optional', '--offline', '--no-audit', '--no-fund', tarball], { cwd: consumer, stdio: 'ignore' })
   const consumerExample = join(consumer, 'ferromark-ardo.mjs')
   await cp(examplePath, consumerExample)
   run(process.execPath, [consumerExample], { cwd: consumer, stdio: 'inherit' })

--- a/node/scripts/check-platform-package.mjs
+++ b/node/scripts/check-platform-package.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const nodeRoot = join(fileURLToPath(new URL('.', import.meta.url)), '..')
+const platformId = process.env.FERRIKI_PLATFORM_ID
+assert(platformId, 'FERRIKI_PLATFORM_ID is required for a platform package check')
+
+const packageDir = join(nodeRoot, 'platforms', platformId)
+const manifest = JSON.parse(await readFile(join(packageDir, 'package.json'), 'utf8'))
+const addon = join(packageDir, 'ferriki.node')
+const info = await stat(addon)
+const npmCache = await mkdtemp(join(tmpdir(), 'ferriki-sidecar-npm-'))
+
+assert.equal(manifest.name, `@sebastian-software/ferriki-${platformId}`)
+assert(manifest.files.includes('ferriki.node'), `${manifest.name} must publish ferriki.node`)
+assert(info.size > 100_000, `${manifest.name} native addon is unexpectedly small (${info.size} bytes)`)
+
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const packed = spawnSync(npm, ['pack', '--dry-run', '--json'], {
+  cwd: packageDir,
+  encoding: 'utf8',
+  env: {
+    ...process.env,
+    npm_config_cache: npmCache,
+    npm_config_update_notifier: 'false',
+  },
+  shell: process.platform === 'win32',
+  stdio: 'pipe',
+})
+if (packed.status !== 0) {
+  await rm(npmCache, { recursive: true, force: true })
+  throw new Error(`${npm} pack failed for ${manifest.name}:\n${packed.stderr}`)
+}
+
+const files = JSON.parse(packed.stdout)[0].files.map(file => file.path)
+assert(files.includes('ferriki.node'), `${manifest.name} dry-run package is missing ferriki.node`)
+await rm(npmCache, { recursive: true, force: true })
+console.log(`Ferriki platform package verified (${manifest.name}, ${info.size} bytes)`)


### PR DESCRIPTION
## Summary
- add publishable manifests for the five supported native targets
- declare matching optional platform dependencies and validate their package contract
- copy each explicit-target build into its sidecar package and smoke-pack it in CI
- keep the main-package packed smoke runnable before coordinated sidecar publication

## Validation
- `pnpm install --frozen-lockfile --offline --ignore-scripts`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run check:platform-matrix`
- `pnpm run check:boundary`
- `pnpm run check:docs`
- `FERRIKI_PLATFORM_ID=darwin-arm64 pnpm run check:platform-package`
- `git diff --check`

Related to #52
Related to #54
