### PR TITLE
chore(release): prepare Ferriki 0.2.1 candidate

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "node/ferriki": "0.2.0"
+  "node/ferriki": "0.2.1"
 }

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -86,7 +86,7 @@ versus target mismatch before release artifacts are assembled.
 
 ## Packaging baseline
 
-The packed `ferriki@0.2.0` main package measured **11,372,892 bytes
+The packed `ferriki@0.2.1` main package measured **11,372,892 bytes
 unpacked** on 2026-09-05 (`npm pack --json`). This is the main-package
 baseline; the release workflow also validates each sidecar tarball before
 publication.

--- a/node/ferriki/CHANGELOG.md
+++ b/node/ferriki/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.1](https://github.com/sebastian-software/ferriki/compare/v0.2.0...v0.2.1) (2026-09-06)
+
+### Features
+
+* **node:** prepare the native sidecar release candidate and public install verification
+
 ## [0.2.0](https://github.com/sebastian-software/ferriki/compare/v0.1.0...v0.2.0) (2026-07-10)
 
 

--- a/node/ferriki/package.json
+++ b/node/ferriki/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ferriki",
   "type": "module",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Shiki-compatible syntax highlighting powered by a native Rust TextMate runtime",
   "license": "MIT",
   "homepage": "https://github.com/sebastian-software/ferriki#readme",
@@ -59,11 +59,11 @@
     "build:native": "node ./scripts/build-native.mjs"
   },
   "optionalDependencies": {
-    "@sebastian-software/ferriki-darwin-arm64": "0.2.0",
-    "@sebastian-software/ferriki-darwin-x64": "0.2.0",
-    "@sebastian-software/ferriki-linux-arm64-gnu": "0.2.0",
-    "@sebastian-software/ferriki-linux-x64-gnu": "0.2.0",
-    "@sebastian-software/ferriki-win32-x64-msvc": "0.2.0"
+    "@sebastian-software/ferriki-darwin-arm64": "0.2.1",
+    "@sebastian-software/ferriki-darwin-x64": "0.2.1",
+    "@sebastian-software/ferriki-linux-arm64-gnu": "0.2.1",
+    "@sebastian-software/ferriki-linux-x64-gnu": "0.2.1",
+    "@sebastian-software/ferriki-win32-x64-msvc": "0.2.1"
   },
   "devDependencies": {
     "@types/node": "catalog:types"

--- a/node/platforms/darwin-arm64/package.json
+++ b/node/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastian-software/ferriki-darwin-arm64",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Ferriki native addon for macOS arm64",
   "license": "MIT",
   "repository": "git+https://github.com/sebastian-software/ferriki.git",

--- a/node/platforms/darwin-x64/package.json
+++ b/node/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastian-software/ferriki-darwin-x64",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Ferriki native addon for macOS x64",
   "license": "MIT",
   "repository": "git+https://github.com/sebastian-software/ferriki.git",

--- a/node/platforms/linux-arm64-gnu/package.json
+++ b/node/platforms/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastian-software/ferriki-linux-arm64-gnu",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Ferriki native addon for Linux arm64 with GNU libc",
   "license": "MIT",
   "repository": "git+https://github.com/sebastian-software/ferriki.git",

--- a/node/platforms/linux-x64-gnu/package.json
+++ b/node/platforms/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastian-software/ferriki-linux-x64-gnu",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Ferriki native addon for Linux x64 with GNU libc",
   "license": "MIT",
   "repository": "git+https://github.com/sebastian-software/ferriki.git",

--- a/node/platforms/win32-x64-msvc/package.json
+++ b/node/platforms/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastian-software/ferriki-win32-x64-msvc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Ferriki native addon for Windows x64 with MSVC",
   "license": "MIT",
   "repository": "git+https://github.com/sebastian-software/ferriki.git",

--- a/node/pnpm-lock.yaml
+++ b/node/pnpm-lock.yaml
@@ -557,19 +557,19 @@ importers:
         version: 25.3.3
     optionalDependencies:
       '@sebastian-software/ferriki-darwin-arm64':
-        specifier: 0.2.0
+        specifier: 0.2.1
         version: link:../platforms/darwin-arm64
       '@sebastian-software/ferriki-darwin-x64':
-        specifier: 0.2.0
+        specifier: 0.2.1
         version: link:../platforms/darwin-x64
       '@sebastian-software/ferriki-linux-arm64-gnu':
-        specifier: 0.2.0
+        specifier: 0.2.1
         version: link:../platforms/linux-arm64-gnu
       '@sebastian-software/ferriki-linux-x64-gnu':
-        specifier: 0.2.0
+        specifier: 0.2.1
         version: link:../platforms/linux-x64-gnu
       '@sebastian-software/ferriki-win32-x64-msvc':
-        specifier: 0.2.0
+        specifier: 0.2.1
         version: link:../platforms/win32-x64-msvc
 
   platforms/darwin-arm64: {}


### PR DESCRIPTION
## Summary
- prepare a new `0.2.1` version because the historical `0.2.0` was unpublished and must not be reused
- synchronize the main package, five optional sidecars, release-please manifest, and lockfile
- document the release-candidate version and packed artifact evidence

## Validation
- `pnpm install --frozen-lockfile --offline --ignore-scripts`
- `pnpm run check:platform-matrix`
- `pnpm run check:release`
- `pnpm run check:docs`
- `pnpm run lint`
- `pnpm run typecheck`

Related to #15 and #52
