### PR TITLE
docs: reconcile compatibility contract status

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ compatibility machinery lives under [`node`](node).
 
 ## Quick Start
 
-Prerequisites: a stable Rust toolchain (`cargo`), Node.js >= 20, and pnpm
+Prerequisites: a stable Rust toolchain (`cargo`), Node.js >= 22.13.0, and pnpm
 (the pinned version in `node/package.json` is picked up via corepack).
 
 Rust:
@@ -95,8 +95,10 @@ checkout and keeps the tracked mirror immutable.
 
 The TextMate compatibility lane runs selected, unchanged Shiki tests with
 honest aliases so every highlighted result passes through the native addon.
-The broader `test:ferriki-compat:core` lane also covers facade work tracked in
-issue #31.
+The broader `test:ferriki-compat:core` lane also runs the Ferriki-owned API,
+error, catalog, registration, multi-theme, transformer, token-state, packaging,
+and Ferromark/Ardo contract checks. Upstream cases outside that accepted
+boundary remain explicitly classified in the compatibility manifest.
 
 ## Compatibility
 
@@ -118,9 +120,10 @@ with Ferriki's asset catalogs, native renderer, N-API host, and focused Node
 surface. Its inner vscode-textmate oracle and honest Shiki v4.4.3 structural
 gate are green.
 
-Issues #47 and #51 own the remaining token/state and lifecycle breadth of the
-Shiki facade. Transformer/decorator behavior remains deliberately outside the
-core runtime until its contract is accepted. The current core direction is:
+The accepted API contract and its focused checks own token/state, lifecycle,
+transformer, and registration behavior. Upstream adapter fixtures that do not
+describe Ferriki's native boundary remain classified as explicit non-goals.
+The current core direction is:
 
 - Rust owns runtime behavior
 - Node is the thin facade and compatibility layer

--- a/node/compat/harness/core-compat-manifest.mjs
+++ b/node/compat/harness/core-compat-manifest.mjs
@@ -13,8 +13,8 @@ export const coreCompatSupportedTests = [
 export const coreCompatDeferredTests = [
   {
     path: 'compat/upstream/shiki/packages/core/test/css-variables.test.ts',
-    reason: 'custom theme registration and CSS variable patching are part of the public facade contract',
-    issue: 31,
+    reason: 'Shiki engine CSS-variable patching is outside the accepted native boundary; Ferriki registration and multi-theme contracts are covered by dedicated checks',
+    issue: 48,
   },
   {
     path: 'compat/upstream/shiki/packages/core/test/tokens.test.ts',
@@ -28,18 +28,18 @@ export const coreCompatDeferredTests = [
   },
   {
     path: 'compat/upstream/shiki/packages/shiki/test/ansi.test.ts',
-    reason: 'ANSI parsing is not part of the current Ferriki facade',
-    issue: 31,
+    reason: 'ANSI escape parsing is an explicit non-goal; Ferriki rejects terminal escape sequences before native execution',
+    issue: 48,
   },
   {
     path: 'compat/upstream/shiki/packages/shiki/test/color-replacement.test.ts',
-    reason: 'color replacement options are not implemented yet',
-    issue: 31,
+    reason: 'the upstream bundle fixture exercises Shiki-only theme plumbing; Ferriki colorReplacements are validated by the native option contract',
+    issue: 48,
   },
   {
     path: 'compat/upstream/shiki/packages/shiki/test/css-variables.test.ts',
-    reason: 'CSS variable theme helpers are not implemented yet',
-    issue: 31,
+    reason: 'the upstream helper fixture is outside the accepted native boundary; Ferriki CSS variables are covered by the multi-theme and registration contracts',
+    issue: 48,
   },
   {
     path: 'compat/upstream/shiki/packages/shiki/test/decorations.test.ts',
@@ -48,8 +48,8 @@ export const coreCompatDeferredTests = [
   },
   {
     path: 'compat/upstream/shiki/packages/shiki/test/dist.test.ts',
-    reason: 'upstream distribution-file assertions do not describe the Ferriki package boundary',
-    issue: 31,
+    reason: 'upstream distribution-file assertions do not describe the Ferriki package boundary; packed Ferriki artifacts have a separate consumer gate',
+    issue: 42,
   },
   {
     path: 'compat/upstream/shiki/packages/shiki/test/grammar-state.test.ts',
@@ -58,27 +58,27 @@ export const coreCompatDeferredTests = [
   },
   {
     path: 'compat/upstream/shiki/packages/shiki/test/hast.test.ts',
-    reason: 'HAST metadata, decorations, and multi-theme rendering are not implemented yet',
-    issue: 31,
+    reason: 'the upstream HAST fixture combines adapter-owned metadata with engine behavior; Ferriki HAST, decoration, and multi-theme contracts are covered by dedicated checks',
+    issue: 45,
   },
   {
     path: 'compat/upstream/shiki/packages/shiki/test/shorthands-markdown.test.ts',
-    reason: 'lazy embedded-language shorthand behavior is not implemented yet',
-    issue: 31,
+    reason: 'Markdown shorthand expansion belongs to an optional adapter, not the Ferriki core product boundary',
+    issue: 42,
   },
   {
     path: 'compat/upstream/shiki/packages/shiki/test/shorthands.test.ts',
-    reason: 'facade error wording and shorthand behavior are not stable yet',
-    issue: 31,
+    reason: 'the upstream shorthand fixture asserts Shiki-specific adapter wording; Ferriki usage errors and native recovery are covered by the error contract',
+    issue: 50,
   },
   {
     path: 'compat/upstream/shiki/packages/shiki/test/theme-none.test.ts',
-    reason: 'none and dual-theme rendering are not implemented yet',
-    issue: 31,
+    reason: 'Ferriki theme-none and dual-theme behavior is covered by the dedicated multi-theme contract rather than the upstream adapter fixture',
+    issue: 43,
   },
   {
     path: 'compat/upstream/shiki/packages/shiki/test/themes.test.ts',
-    reason: 'dual-theme, multi-theme, and defaultColor behavior are not implemented yet',
-    issue: 31,
+    reason: 'Ferriki multi-theme and defaultColor behavior is covered by the dedicated native contract with deterministic output assertions',
+    issue: 43,
   },
 ]

--- a/plans/ferriki-remaining-work.md
+++ b/plans/ferriki-remaining-work.md
@@ -29,16 +29,17 @@ Already true:
 - transitional naming is resolved: the addon is `ferriki.node`; the
   compatibility harness uses `FERRIKI_HONEST_ALIAS=1` for native routing
 
-Open work is tracked by the current GitHub backlog, including the typed public
-API (#10), release hardening and sidecars (#15, #52–#54), and the
-Ferromark/Ardo adoption path (#14, #18, #38). The old JS bundle/chunk runtime
+Open work is tracked by the current GitHub backlog, including public npm
+availability and sidecars (#15, #52), and the Ferromark/Ardo adoption path
+(#14, #18, #38). The old JS bundle/chunk runtime
 and placeholder-only package described by earlier migration snapshots are no
 longer present.
 
 The public API source-of-truth lane now lives under [`node/ferriki/src`](../node/ferriki/src):
 `api.mts` is compiled to `api.d.mts`, and the package-root runtime/type entry
 points are generated wrappers checked for drift in CI. The remaining API work
-is tracked in #10 for any future contract additions.
+is tracked by the accepted contract document and its focused checks; future
+additions require a new contract decision.
 
 ## 1. Fix Core Compatibility Gaps
 
@@ -185,18 +186,16 @@ Goal: make the repo easy to build, test, and release without historical context.
 
 Already resolved:
 
-- publishing goes through `publish.yml`, which delegates to the shared
-  `sebastian-software/ferramenta` release workflow: release-please for
-  versioning, `build:native` on five platform targets, binary
-  verification, and npm Trusted Publishing
+- publishing goes through the repository-owned `publish.yml`: release-please
+  versioning, `build:native` on five platform targets, sidecar verification,
+  npm Trusted Publishing, public registry/provenance verification, and a clean
+  consumer install
 - the workspace root is `private: true`; the publishable package is
   [`node/ferriki`](../node/ferriki)
 - Rust checks (fmt, clippy, tests) run in CI
 
 Remaining work:
 
-- continue tightening the checked-in `index.d.mts` contract as API issues
-  land (#10, #31)
 - decide whether and when `ferriki-core` becomes a separately published crate
 - add a CONTRIBUTING.md documenting the normal local workflow:
   - Rust checks


### PR DESCRIPTION
## Summary
- classify every deferred upstream compatibility fixture as an explicit non-goal or a covered Ferriki-owned contract
- remove stale Node/API/release guidance from README and the execution ledger
- document that the mandatory core lane owns native routing, mirror immutability, and the focused contract checks

## Validation
- `pnpm run test:ferriki-compat:core`
- `pnpm run check:docs`
- `pnpm run check:release`
- `pnpm run check:platform-matrix`
- `pnpm run lint`
- `pnpm run typecheck`
- `cargo test --workspace`

Closes #36
