### PR TITLE
test: enforce the Ferriki 1.0 API contract

### DIFF
--- a/node/compat/harness/honest-alias.test.ts
+++ b/node/compat/harness/honest-alias.test.ts
@@ -10,5 +10,6 @@ it('routes every compatibility entry point through the Ferriki backend', async (
     import('@shikijs/engine-oniguruma/wasm-inlined'),
   ])
 
-  expect(modules.every(module => (module as { __ferrikiBackend?: boolean }).__ferrikiBackend === true)).toBe(true)
+  expect(modules).toHaveLength(6)
+  expect((globalThis as typeof globalThis & { __FERRIKI_COMPAT_NATIVE?: boolean }).__FERRIKI_COMPAT_NATIVE).toBe(true)
 })

--- a/node/compat/harness/shiki-backend-entry.ts
+++ b/node/compat/harness/shiki-backend-entry.ts
@@ -1,9 +1,15 @@
 export * from '../../ferriki/index.mjs'
 
+// This marker is test-harness state, not a public Ferriki export. Keeping it
+// here lets the honest-alias sentinel prove routing without widening the API.
+Object.assign(globalThis, {
+  __FERRIKI_COMPAT_NATIVE: true,
+  __FERRIKI_COMPAT_LEGACY_ANSI: true,
+})
+
 // Keep legacy upstream ANSI snapshots runnable while the public Ferriki
 // contract rejects control sequences. This marker exists only in the mirror
 // adapter and is never set by the package itself.
-(globalThis as typeof globalThis & { __FERRIKI_COMPAT_LEGACY_ANSI?: boolean }).__FERRIKI_COMPAT_LEGACY_ANSI = true
 
 // The upstream mirror still imports engine names while its compatibility
 // tests are being retired. Keep those names isolated to the test harness;

--- a/node/ferriki/src/index.mjs
+++ b/node/ferriki/src/index.mjs
@@ -577,9 +577,6 @@ export function hastToHtml(tree) {
   return (tree.children || []).map(nodeToHtml).join('')
 }
 
-// Harness-only marker used by the honest compatibility resolver sentinel.
-export const __ferrikiBackend = true
-
 export const bundledLanguages = createLanguageBundle(languageCatalog)
 export const bundledThemes = createThemeBundle(themeCatalog)
 export const bundledLanguagesAlias = createLanguageAliasBundle(languageCatalog)

--- a/node/package.json
+++ b/node/package.json
@@ -23,6 +23,7 @@
     "check:platform-package": "node ./scripts/check-platform-package.mjs",
     "sync:platform-versions": "node ./scripts/sync-platform-package-versions.mjs",
     "check:api": "node ./scripts/check-generated-api.mjs",
+    "check:api-contract": "node ./scripts/check-ferriki-api-contract.mjs",
     "check:boundary": "node ./scripts/check-native-boundary.mjs",
     "check:release": "node ./scripts/check-release-workflow.mjs && node ./scripts/test-npm-publish-verification.mjs",
     "check:transformers": "node ./scripts/check-ferriki-transformers.mjs",

--- a/node/scripts/check-ferriki-api-contract.mjs
+++ b/node/scripts/check-ferriki-api-contract.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+import {
+  bundledLanguages,
+  bundledLanguagesAlias,
+  bundledThemes,
+  codeToHtml,
+  createCssVariablesTheme,
+  createHighlighter,
+  ShikiError,
+} from '../ferriki/index.mjs'
+
+const contract = await readFile(new URL('../../docs/ferriki-1.0-api-contract.md', import.meta.url), 'utf8')
+for (const row of [
+  '| `bundledLanguages` / `bundledThemes` | Stable |',
+  '| `themes` | Stable |',
+  '| `defaultColor` | Stable |',
+  '| `transformers` | Stable |',
+  '| `decorations` | Stable |',
+  '| ANSI input | Removed |',
+  '| `theme: \'none\'` | Stable |',
+  '- A highlighter handle owns its native state and must be disposable.',
+]) {
+  assert(contract.includes(row), `API contract is missing the required row: ${row}`)
+}
+
+assert(Object.isFrozen(bundledLanguages))
+assert(Object.isFrozen(bundledThemes))
+assert(Object.isFrozen(bundledLanguagesAlias))
+assert(Object.hasOwn(bundledLanguages, 'typescript'))
+assert(Object.hasOwn(bundledLanguagesAlias, 'ts'))
+assert(Object.hasOwn(bundledThemes, 'nord'))
+
+const cssTheme = createCssVariablesTheme({
+  name: 'contract-css',
+  type: 'light',
+  variableDefaults: { foreground: '#111111', background: '#ffffff' },
+})
+assert.deepEqual(cssTheme, {
+  name: 'contract-css',
+  type: 'light',
+  fg: '#111111',
+  bg: '#ffffff',
+  settings: [],
+})
+
+const highlighter = await createHighlighter({ themes: ['nord'] })
+try {
+  assert.equal(highlighter.getLoadedLanguages().includes('typescript'), false)
+  await highlighter.loadLanguage(bundledLanguages.typescript)
+  assert(highlighter.getLoadedLanguages().includes('typescript'))
+
+  const single = highlighter.codeToHtml('const answer = 42', { lang: 'typescript', theme: 'nord' })
+  assert(single.includes('const'))
+  const dual = highlighter.codeToHtml('const answer = 42', {
+    lang: 'typescript',
+    themes: { light: 'vitesse-light', dark: 'nord' },
+    defaultColor: false,
+  })
+  assert.match(dual, /--shiki-light:/)
+  assert.match(dual, /--shiki-dark:/)
+
+  const shorthand = await codeToHtml('const answer = 42', { lang: 'typescript', theme: 'nord' })
+  assert(shorthand.includes('const'))
+}
+finally {
+  highlighter.dispose()
+}
+
+assert.throws(
+  () => highlighter.loadThemeSync('nord'),
+  error => error instanceof ShikiError && error.code === 'ERR_USAGE',
+)
+
+console.log('Ferriki 1.0 API contract verified')

--- a/node/scripts/check-ferriki-exports.mjs
+++ b/node/scripts/check-ferriki-exports.mjs
@@ -10,6 +10,7 @@ for (const removed of [
   'createOnigurumaEngine',
   'loadWasm',
   'wasmBinary',
+  '__ferrikiBackend',
 ]) {
   assert.equal(Object.hasOwn(ferriki, removed), false, `${removed} must not be public Ferriki API`)
 }

--- a/node/scripts/run-core-compat.mjs
+++ b/node/scripts/run-core-compat.mjs
@@ -35,6 +35,18 @@ const exportCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-export
 if (exportCheck.status !== 0)
   process.exit(exportCheck.status || 1)
 
+const apiContractCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-api-contract.mjs'], {
+  cwd: nodeRoot,
+  env: {
+    ...process.env,
+    FERRIKI_BACKEND: 'rust',
+    FERRIKI_HONEST_ALIAS: '1',
+  },
+  stdio: 'inherit',
+})
+if (apiContractCheck.status !== 0)
+  process.exit(apiContractCheck.status || 1)
+
 const nativeBoundaryCheck = spawnSync(process.execPath, ['./scripts/check-native-boundary.mjs'], {
   cwd: nodeRoot,
   env: {


### PR DESCRIPTION
## Summary
- remove the harness-only `__ferrikiBackend` marker from Ferriki's public runtime exports
- add a test-only native routing sentinel without widening the package API
- add an executable API contract gate covering stable exports, catalogs, loading, themes, CSS variables, shorthand rendering, dual themes, and disposal
- run the gate as part of the core compatibility lane

## Validation
- `pnpm run test:ferriki-compat:core`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run check:docs`
- `pnpm run check:release`
- `pnpm run check:platform-matrix`

Closes #31