### PR TITLE
fix(api): expose bundled language and theme key types

### DIFF
--- a/docs/ferriki-api.md
+++ b/docs/ferriki-api.md
@@ -18,7 +18,7 @@ The retained declaration symbols are `LanguageRegistration`,
 `codeToTokensBase`, `codeToTokensWithThemes`, `getLastGrammarState`,
 `CssVariablesThemeOptions`, `createCssVariablesTheme`, `hastToHtml`,
 `bundledLanguages`, `bundledThemes`, `bundledLanguagesAlias`, and
-`FerrikiErrorCode`, `FerrikiError`.
+`BundledLanguage`, `BundledTheme`, `FerrikiErrorCode`, `FerrikiError`.
 
 ## Runtime requirements
 
@@ -188,6 +188,8 @@ catalog cannot be overwritten.
 
 `bundledLanguages` and `bundledThemes` are frozen, enumerable loader maps.
 `bundledLanguagesAlias` maps every bundled alias to its canonical language ID.
+`BundledLanguage` and `BundledTheme` are key unions for those maps and are
+provided for typed consumers such as Ardo configuration and language guards.
 
 ## Results and helpers
 

--- a/node/ferriki/src/api.d.mts
+++ b/node/ferriki/src/api.d.mts
@@ -234,3 +234,5 @@ export declare function hastToHtml(tree: HastRoot | HastElement): string;
 export declare const bundledLanguages: Readonly<Record<string, () => Promise<LanguageRegistration[]>>>;
 export declare const bundledThemes: Readonly<Record<string, () => Promise<ThemeRegistration>>>;
 export declare const bundledLanguagesAlias: Readonly<Record<string, string>>;
+export type BundledLanguage = keyof typeof bundledLanguages;
+export type BundledTheme = keyof typeof bundledThemes;

--- a/node/ferriki/src/api.mts
+++ b/node/ferriki/src/api.mts
@@ -308,3 +308,5 @@ export declare const bundledThemes: Readonly<
   Record<string, () => Promise<ThemeRegistration>>
 >
 export declare const bundledLanguagesAlias: Readonly<Record<string, string>>
+export type BundledLanguage = keyof typeof bundledLanguages
+export type BundledTheme = keyof typeof bundledThemes


### PR DESCRIPTION
## Summary
- expose `BundledLanguage` and `BundledTheme` as public key types for the frozen catalog maps
- document the aliases in the Ferriki API reference
- restore Ardo/TypeDoc compatibility without adding private hooks or runtime surface

## Validation
- Ferriki `check:docs` / packed consumer
- Ferriki typecheck and lint
- Ardo packed-artifact integration: 58 unit test files, 227 tests passed
- Ardo package typecheck and build
- Ardo docs production build: TypeDoc generated 46 API pages and prerender completed

Refs #38
Refs #14