### PR TITLE
fix(ci): make v0.3.0 platform release verifiable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      - name: Synchronize platform package versions
+        run: pnpm run sync:platform-versions
+
       - name: Run honest supported core compatibility gate
         run: pnpm run test:ferriki-compat:core
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -216,7 +216,7 @@ jobs:
         working-directory: node
         run: |
           for platform_id in linux-x64-gnu linux-arm64-gnu darwin-arm64 darwin-x64 win32-x64-msvc; do
-            npm publish "platforms/$platform_id" --access public --provenance --tag "$NPM_DIST_TAG"
+            npm publish "./platforms/$platform_id" --access public --provenance --tag "$NPM_DIST_TAG"
           done
 
       - name: Publish main package with npm provenance
@@ -242,9 +242,11 @@ jobs:
           node-version: '22'
 
       - name: Verify public npm packages, provenance, and install
+        run: |
+          node ./node/scripts/sync-platform-package-versions.mjs
+          node ./node/scripts/verify-npm-publish.mjs
         env:
           NPM_PUBLISH_RESULT: ${{ needs.publish-npm.result }}
-        run: node ./node/scripts/verify-npm-publish.mjs
 
   release-summary:
     needs:


### PR DESCRIPTION
## Summary

- synchronize platform package versions before the core compatibility gate and npm verification
- publish local platform package directories with an explicit `./` path

## Why

The v0.3.0 release PR and post-release CI failed because the source manifests still contain the previous `0.2.1` sidecar versions, while the main package is `0.3.0`. The publish job also passed `platforms/<target>` to npm, which npm interpreted as a GitHub repository shorthand (`ssh://git@github.com/platforms/...`).

## Validation

- `corepack pnpm@10.28.2 -C node run check:release`
- `corepack pnpm@10.28.2 -C node run test:ferriki-compat:core`
- `git diff --check`
