### PR TITLE
chore: apply @sebastian-software/standards v9

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default owners for everything in this repository.
+# GitHub applies the LAST matching pattern, so put more specific rules BELOW
+# this line, never above it — a rule above the catch-all would be overridden.
+* @sebastian-software/maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Report a reproducible defect.
+title: "[Bug]: "
+labels:
+  - "type:bug"
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+      placeholder: A short description of the unexpected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Version or commit, operating system, and the toolchain or runtime version you used.
+      placeholder: |
+        version 1.2.3
+        Linux 6.12
+        Node 24
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: The smallest command, input, or code sample that reproduces the problem.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the full error output or log where you have one.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Triage checklist
+      options:
+        - label: I searched the existing issues for duplicates.
+          required: true
+        - label: I removed credentials and private data from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/sebastian-software/ferriki/security/advisories/new
+    about: Do not open a public issue. Use "Report a vulnerability" on this repository's Security tab, or email security@sebastian-software.de.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Propose a focused improvement.
+title: "[Feature]: "
+labels:
+  - "type:feature"
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Which user or maintainer problem would this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: The smallest focused behavior, API, or option that would address the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Which existing commands, APIs, or workflows did you try first?
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Triage checklist
+      options:
+        - label: I searched the existing issues for duplicates.
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,24 @@
+name: Question
+description: Ask a focused usage or contributor question.
+title: "[Question]: "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Read `SUPPORT.md` and the documentation first. When this repository has Discussions enabled, ask there instead.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What are you trying to do, and where are you blocked?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: The command or API call, the version, and the documentation page involved. Remove credentials and private data.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What changed and why, in one or two sentences. -->
+
+## Changes
+
+<!-- The notable changes, one bullet each. Call out user-visible or breaking behavior. -->
+
+## Validation
+
+<!-- The commands you ran and their result, or a note that this change is documentation-only. -->
+
+## Issue
+
+<!-- Closes #123, Refs #123, or a short note on why no issue exists. -->

--- a/.repometa.json
+++ b/.repometa.json
@@ -1,5 +1,5 @@
 {
-  "standards": 6,
+  "standards": 9,
   "visibility": "oss",
   "since": 2026,
   "platform": "github"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,23 @@ not a status ledger; check the linked issue before relying on an old finding.
 
 - Do not hand-edit managed files or standards-owned marker sections.
 - If `standards check` reports drift, run `standards apply` or update standards.
-- `pnpm agent:check` may omit `standards check`; CI can still fail on drift.
+- The repository's own gate may omit `standards check`; CI can still fail on it.
+
+Node repositories:
+
 - Fix or format every file reported by `oxfmt` whenever practical.
 - For generated files, prefer formatting in the generator step.
 - If formatting is not viable, use repo-local `.prettierignore`.
 - Never add repo-specific ignores to managed `.oxfmtrc.json`.
+
+Rust repositories:
+
+- Keep `cargo fmt --all --check` and
+  `cargo clippy --workspace --all-targets --all-features -- -D warnings` green.
+- Lint levels belong in `[workspace.lints]`, never in managed `rustfmt.toml`.
+- `rust-version` in `Cargo.toml` is the only MSRV; every other mention is a
+  derived copy.
+- Record a cargo-deny finding as a narrow, commented exception in `deny.toml` —
+  never by widening the org allow-list.
+
 <!-- sebastian-software-consumer-agents:end -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Code of Conduct
+
+This project is committed to a welcoming, respectful, and constructive
+environment for everyone who takes part in it.
+
+## Expected behavior
+
+- Be respectful of different viewpoints, backgrounds, and levels of experience.
+- Give and receive feedback about the work, not about a person's worth or
+  identity.
+- Keep discussions focused on the project, its users, and its documented goals.
+- Accept correction gracefully and help make the next contribution easier.
+
+## Unacceptable behavior
+
+Harassment, discrimination, intimidation, personal attacks, doxxing, sexualized
+language or attention, and deliberate disruption are not acceptable. Do not
+publish private information, credentials, or material you are not allowed to
+share.
+
+## Scope and enforcement
+
+This code applies in project spaces, including issues, pull requests, reviews,
+and project-related communication. Maintainers may remove comments, close
+discussions, reject contributions, or restrict participation when that is needed
+to protect the community and the project.
+
+## Reporting
+
+Report unacceptable behavior privately rather than opening a public issue. Two
+routes are available:
+
+- **The repository maintainers**, through GitHub — for everyday reports about
+  behavior in project spaces.
+- **security@sebastian-software.de** — a private inbox at Sebastian Software
+  GmbH, independent of any individual repository maintainer. Use it when the
+  report concerns a maintainer, or whenever you would rather not write to the
+  maintainers directly. It is the same address as for security reports; conduct
+  reports sent there are handled confidentially as conduct reports.
+
+Reports are reviewed as promptly and confidentially as practical. Include links,
+dates, and relevant context, but no credentials and no data you are not allowed
+to share.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ This project is part of [Ferramenta](https://ferramenta.dev) — the family of R
 ---
 
 <!-- sebastian-software-branding:start -->
+
 <p align="center">
   <a href="https://oss.sebastian-software.com">
     <img src="https://sebastian-brand.vercel.app/sebastian-software/logo-software.svg" alt="Sebastian Software" width="240" />
@@ -171,4 +172,5 @@ This project is part of [Ferramenta](https://ferramenta.dev) — the family of R
 </p>
 
 <p align="center">Copyright &copy; 2026 Sebastian Software GmbH</p>
+
 <!-- sebastian-software-branding:end -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided for the latest release on the default branch. Older
+releases are not patched separately — upgrade to the latest version to receive a
+fix.
+
+## Reporting a vulnerability
+
+Report suspected vulnerabilities privately. Do not open a public issue, pull
+request, or discussion for a vulnerability that has not been fixed yet.
+
+Two private channels are available:
+
+- **GitHub private vulnerability reporting** — open this repository's
+  **Security** tab and choose **Report a vulnerability**.
+- **Email** — security@sebastian-software.de.
+
+Include a concise description, the affected version or commit, reproduction
+steps, the impact you expect, and any suggested fix. Leave out credentials and
+data you are not allowed to share.
+
+## Response expectations
+
+Maintainers aim to:
+
+- Acknowledge a private report within 7 days.
+- Assess severity and affected versions within 14 days.
+- Coordinate a fix and a disclosure timeline with the reporter.
+- Credit the reporter when desired and appropriate.
+
+Timing can vary for low-impact reports and for reports that depend on a fix in
+an upstream dependency.
+
+## Scope
+
+In scope: anything in this repository that lets someone read, modify, or execute
+something they should not — including the released artifacts and the build and
+release automation.
+
+Usually out of scope: reports without a concrete impact path, vulnerabilities in
+third-party dependencies used as documented, and problems that require an
+already-compromised machine or a deliberately corrupted local state.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,23 @@
+# Support
+
+Start with the `README.md` and, where the repository has one, the `docs/`
+directory. Then pick the channel that matches your request.
+
+## Usage questions
+
+Use the repository's **Discussions** tab when it is enabled; otherwise open a
+**Question** issue. Describe what you are trying to do, the version you are on,
+your platform, and the exact command or API call. Remove credentials and private
+data from examples.
+
+## Bugs and feature requests
+
+Use the **Bug report** or **Feature request** issue form. Search the existing
+issues first. Keep a bug report reproducible and focused on one behavior, and
+keep a feature request focused on the problem it solves.
+
+## Security
+
+Do not report a vulnerability in a public issue or discussion. Follow
+[SECURITY.md](SECURITY.md): private reporting through this repository's
+**Security** tab, or by email to security@sebastian-software.de.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,6 @@
+# Managed by @sebastian-software/standards — edit the reference, not this copy.
+# The org formats with rustfmt defaults; only the edition and the line ending
+# are fixed, so every repository runs rustfmt with the same options. The rustfmt
+# build itself comes from the repository's toolchain.
 edition = "2024"
 newline_style = "Unix"


### PR DESCRIPTION
## Summary

Moves the repository from standards version 6 to 9 (`@sebastian-software/standards@0.8.0`). `standards check` reported 13 findings before the run: the stale stamp, nine missing common-scope seeded files, both marker sections outdated, and `rustfmt.toml` differing from the managed reference. `standards apply` fixed all of them and a second `check` is clean.

Only the `common` and `rust` scopes detect here. The `node` scope needs a `package.json` at the repository root and Ferriki keeps its Node workspace under `node/`, so nothing Node-side (for example a managed `.oxfmtrc.json`) is seeded or checked — worth a family decision if the org wants those files in nested workspaces.

## Changes

- Seeded the community baseline, all new files: `SECURITY.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, `.github/CODEOWNERS`, the bug report / feature request / question issue forms with `config.yml`, and `.github/pull_request_template.md`. Nothing was merged or overwritten — the repository had none of them.
- Re-rendered the standards-owned marker sections: `sebastian-software-branding` in `README.md` (blank lines before/after, so oxfmt and `apply` stop disagreeing) and `sebastian-software-consumer-agents` in `AGENTS.md`, which now splits the guardrails into a scope-agnostic core plus Node and Rust groups. Repository-local guidance above the markers is untouched.
- `rustfmt.toml` is managed as of version 9 and gained the reference header comment. The options are byte-identical to what was already there (`edition = "2024"`, `newline_style = "Unix"`).
- `.repometa.json` stamped to 9.

### Judgement steps

- Pointed the issue chooser's security link at `https://github.com/sebastian-software/ferriki/security/advisories/new` (the seed carries a repo-independent GitHub documentation URL because seeded files are copied verbatim).
- Kept the seeded `@sebastian-software/maintainers` catch-all in `CODEOWNERS`.
- `deny.toml` and `rust-toolchain.toml` are seeded, not managed: the versions added in #104/#105 were left exactly as they are, and `apply` did not touch them.
- `CLAUDE.md` was already the `@AGENTS.md` pointer with the real guidance in `AGENTS.md`, so step 7 of change 0008 needed no work. There were no legacy Markdown issue templates and no PR template to merge, and no `.prettierignore` workaround to drop.
- Labels were **not** applied — `reference/common/labels.json` is reference data and `standards apply` never touches labels.

## Validation

- `pnpm dlx @sebastian-software/standards@0.8.0 check` → 13 findings; after `apply` → `✓ Repository matches org standards.`
- `cargo fmt --all --check` → clean (relevant because `rustfmt.toml` is now managed).
- From `node/`: `node scripts/check-docs-drift.mjs` and `node scripts/test-docs-drift.mjs` → pass. The docs-drift contract pins `CLAUDE.md` to the pointer line and forbids stale phrases and off-floor Node versions in `AGENTS.md`; the rewritten marker section satisfies it unchanged, so no test expectation was adjusted.
- `node scripts/check-workflow-pins.mjs` (61 references, 2 workflows) and `node node/scripts/check-docs-contract.mjs` → pass.

## Left for the owner

- Enable private vulnerability reporting in the repository settings, otherwise the issue chooser's security link 404s.
- Confirm the `@sebastian-software/maintainers` team exists with write access.
- Apply the label taxonomy from `reference/common/labels.json` with `gh label`, renaming existing spellings rather than recreating them.
- Not covered here, still open on #95: the "compatibility gap vs Shiki" issue form, a PR template mirroring the CI lanes, the root CHANGELOG pointer, and the `plans/` decision. CI has no `standards check` lane yet, so managed drift would only show up locally.

## Issue

Refs #93, Refs #95, Refs sebastian-software/ferramenta#6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFZKSZqbtZnUT5tSVEB81M

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFZKSZqbtZnUT5tSVEB81M)_