### PR TITLE
docs(readme): render the family block from the ferramenta registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,12 @@ jobs:
       - name: Verify the release workflow and checklist contract
         run: pnpm run check:release
 
+      # The family block in both READMEs is generated from the registry in
+      # sebastian-software/ferramenta; this fails when either has drifted.
+      - name: Verify the generated Ferramenta family block
+        working-directory: ${{ github.workspace }}
+        run: node scripts/sync-readme-family.mjs --check
+
   typecheck:
     runs-on: ubuntu-latest
     defaults:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,9 @@ cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 
+# Both READMEs carry a generated family block (needs network)
+node scripts/sync-readme-family.mjs --check
+
 # Node workspace: install, build the native addon, run the release gate
 cd node
 pnpm install --ignore-scripts
@@ -87,6 +90,38 @@ they were written and are deliberately outside the check.
 `node/scripts/test-docs-drift.mjs` runs the same check against fixture copies
 of the documents with stale versions injected, so a change to the checker that
 stops detecting drift fails alongside it.
+
+## The Ferramenta family block
+
+Ferriki is one of the [Ferramenta](https://ferramenta.dev) tools, and both
+READMEs end with a block naming its siblings: the grouped tables in the root
+`README.md`, and the two plain-Markdown lines in `node/ferriki/README.md`,
+which is what npmjs.com renders. Neither is hand-written. Both are rendered
+from `src/family.ts` in
+[sebastian-software/ferramenta](https://github.com/sebastian-software/ferramenta),
+the single source of truth for every tool's name, job and link.
+
+```sh
+node scripts/sync-readme-family.mjs           # rewrite both blocks
+node scripts/sync-readme-family.mjs --check   # fail when either has drifted
+```
+
+`scripts/sync-readme-family.mjs` runs the `ferramenta-readme` generator through
+`pnpm dlx`, so it needs network access and the Node floor this repository
+already declares. The generator compares content rather than
+whitespace, so a formatter padding table cells is not drift. The CI `lint` job
+runs the `--check` form; `node/scripts/check-docs-contract.mjs` additionally
+holds the `<!-- ferramenta-family:start -->` markers in place without network.
+
+The registry commit is pinned once, in `REGISTRY_PIN` at the top of that
+script, so the block a CI run blesses today is the one it blessed yesterday.
+When the registry changes — a new member, a renamed tool, a reworded job —
+adopt it by bumping `REGISTRY_PIN` to the new ferramenta commit, rerunning the
+script without `--check`, and committing the regenerated blocks together with
+the pin. Do not edit the text between the markers by hand; the next run
+overwrites it. The platform sidecar packages under `node/platforms/` are
+install-time artifacts rather than a product surface and deliberately carry no
+block.
 
 ## Commits and releases
 

--- a/README.md
+++ b/README.md
@@ -143,17 +143,31 @@ at your option.
 <!-- ferramenta-family:start -->
 ## The Ferramenta family
 
-This project is part of [Ferramenta](https://ferramenta.dev) — the family of Rust-native developer tools by [Sebastian Software](https://oss.sebastian-software.com) that keep the APIs the ecosystem already knows:
+This project is part of [Ferramenta](https://ferramenta.dev) — the family of Rust-native developer tools by [Sebastian Software](https://oss.sebastian-software.com) that keep the APIs the ecosystem already knows.
+
+**The content pipeline**
 
 | Tool | Job |
 | --- | --- |
-| [ferroni](https://github.com/sebastian-software/ferroni) | Oniguruma-compatible regex engine |
+| [ferroni](https://sebastian-software.github.io/ferroni/) | Oniguruma-compatible regex engine |
 | **[ferriki](https://github.com/sebastian-software/ferriki)** | Shiki-compatible syntax highlighting |
-| [ferromark](https://github.com/sebastian-software/ferromark) | CommonMark/GFM Markdown to HTML |
+| [ferromark](https://sebastian-software.github.io/ferromark/) | Markdown to HTML — CommonMark & GFM |
+
+**The language workshop**
+
+| Tool | Job |
+| --- | --- |
+| [ferrolex](https://github.com/sebastian-software/ferrolex) | Spell checking for text and code |
+| [ferrocat](https://ferrocat.dev) | Translation catalog engine |
+| [palamedes](https://palamedes.dev) | Internationalization for TypeScript applications |
+
+**On the workbench**
+
+| Tool | Job |
+| --- | --- |
 | [ferrovia](https://github.com/sebastian-software/ferrovia) | SVGO-compatible SVG optimizer |
-| [ferrocat](https://github.com/sebastian-software/ferrocat) | Translation catalog engine |
-| [ferrolex](https://github.com/sebastian-software/ferrolex) | Spell, dictionary, and brand validation |
-| [ferrugo](https://github.com/sebastian-software/ferrugo) | Rust-native PDF previews |
+| [ferralk](https://github.com/sebastian-software/ferralk) | Glob matching and parallel filesystem walking |
+| [ferrugo](https://github.com/sebastian-software/ferrugo) | PDF previews for untrusted files |
 <!-- ferramenta-family:end -->
 
 ---

--- a/node/ferriki/README.md
+++ b/node/ferriki/README.md
@@ -150,3 +150,9 @@ Licensed under either of
 [MIT](https://github.com/sebastian-software/ferriki/blob/main/LICENSE-MIT) or
 [Apache-2.0](https://github.com/sebastian-software/ferriki/blob/main/LICENSE-APACHE)
 at your option.
+
+<!-- ferramenta-family:start -->
+**ferriki** is part of the [Ferramenta](https://ferramenta.dev) family — Rust-native developer tools that keep the APIs the ecosystem already knows.
+
+Siblings: [ferroni](https://sebastian-software.github.io/ferroni/) · [ferromark](https://sebastian-software.github.io/ferromark/) · [ferrolex](https://github.com/sebastian-software/ferrolex) · [ferrocat](https://ferrocat.dev) · [palamedes](https://palamedes.dev) · [ferrovia](https://github.com/sebastian-software/ferrovia) · [ferralk](https://github.com/sebastian-software/ferralk) · [ferrugo](https://github.com/sebastian-software/ferrugo).
+<!-- ferramenta-family:end -->

--- a/node/scripts/check-docs-contract.mjs
+++ b/node/scripts/check-docs-contract.mjs
@@ -50,6 +50,23 @@ assert.doesNotMatch(
   /\]\(\.\.\//,
   'package README must not use repository-relative links',
 )
+
+// The block itself is generated from the family registry and verified against
+// it by `node scripts/sync-readme-family.mjs --check`; this only holds the
+// markers in place, so a README cannot quietly lose the family block offline.
+const familyBlockReadmes = [
+  ['README.md', rootReadme],
+  ['node/ferriki/README.md', packageReadme],
+]
+for (const [label, content] of familyBlockReadmes) {
+  for (const marker of ['<!-- ferramenta-family:start -->', '<!-- ferramenta-family:end -->']) {
+    assert(
+      content.includes(marker),
+      `${label} must keep ${marker}; regenerate with \`node scripts/sync-readme-family.mjs\``,
+    )
+  }
+}
+
 assert(troubleshooting.includes('No native binary for <platform>-<arch>'), 'troubleshooting must start from the actual loader error')
 
 console.log(`Ferriki docs contract verified (${exportedNames.length} declared exports, ${source.ref} baseline)`)

--- a/scripts/sync-readme-family.mjs
+++ b/scripts/sync-readme-family.mjs
@@ -1,0 +1,74 @@
+// The Ferramenta family block in both READMEs is rendered from the family
+// registry in sebastian-software/ferramenta, so a new member, a renamed tool
+// or a reworded job reaches this repository by bumping one pin and rerunning
+// this script — not by hand-editing two tables that then drift apart.
+//
+// Without an argument (or with `--write`) the script writes the block. With
+// `--check` it fails when a README has drifted; the generator compares
+// content, not whitespace, so a Markdown formatter padding table cells and
+// adding blank lines around HTML comments is not drift.
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+// The single pin for this repository. Bump it to adopt a registry change,
+// then rerun the script without `--check` and commit the regenerated block.
+const REGISTRY_PIN = 'd63a0b163ef3e5e68cd1c77e5c8871ac72c36b60'
+
+// The `&path:` part is required: without it pnpm installs the site instead of
+// the package and there is no `ferramenta-readme` binary to run.
+const GENERATOR = `github:sebastian-software/ferramenta#${REGISTRY_PIN}&path:/packages/ardo-config`
+const TOOL = 'ferriki'
+
+// The root README carries the full grouped block. `node/ferriki/README.md` is
+// what npmjs.com renders, and npm strips the HTML the `github` variant uses,
+// so it carries the two-line `registry` variant. The platform sidecar packages
+// under `node/platforms/` are install-time artifacts, not a product surface,
+// and deliberately carry no block.
+const TARGETS = [
+  { readme: 'README.md', variant: 'github' },
+  { readme: 'node/ferriki/README.md', variant: 'registry' },
+]
+
+const repoRoot = join(fileURLToPath(new URL('.', import.meta.url)), '..')
+
+const args = process.argv.slice(2)
+const unknown = args.filter(arg => arg !== '--check' && arg !== '--write')
+if (unknown.length > 0) {
+  console.error(`[sync-readme-family] unknown argument: ${unknown.join(' ')}`)
+  console.error('usage: node scripts/sync-readme-family.mjs [--check | --write]')
+  process.exit(2)
+}
+
+const mode = args.includes('--check') ? '--check' : '--write'
+
+// Windows cannot spawn `pnpm.cmd` without a shell, and a shell would read the
+// `&` in the generator reference as a command separator, so quote it there.
+const shell = process.platform === 'win32'
+const generator = shell ? `"${GENERATOR}"` : GENERATOR
+
+let failed = false
+for (const target of TARGETS) {
+  const result = spawnSync(
+    'pnpm',
+    ['dlx', generator, '--current', TOOL, '--variant', target.variant, mode, target.readme],
+    { cwd: repoRoot, shell, stdio: 'inherit' },
+  )
+
+  if (result.error) {
+    console.error(`[sync-readme-family] could not run pnpm: ${result.error.message}`)
+    process.exit(2)
+  }
+
+  if (result.status !== 0) {
+    failed = true
+    if (mode === '--check')
+      console.error(`[sync-readme-family] ${target.readme} is out of date — rerun \`node scripts/sync-readme-family.mjs\``)
+  }
+}
+
+if (failed)
+  process.exit(1)
+
+console.log(`[sync-readme-family] ${mode === '--check' ? 'verified' : 'wrote'} ${TARGETS.length} README family blocks from registry pin ${REGISTRY_PIN.slice(0, 7)}`)


### PR DESCRIPTION
## Summary

Both READMEs stopped describing the Ferramenta family by hand: the root block was hand-copied and out of date (old job strings, no ferralk, no palamedes), and the npm README named no sibling at all. Both are now rendered from `src/family.ts` in [sebastian-software/ferramenta](https://github.com/sebastian-software/ferramenta), the single source of truth for every tool's name, job and link.

## Changes

- `scripts/sync-readme-family.mjs` — holds the one registry pin (`REGISTRY_PIN`) and runs the `ferramenta-readme` generator through `pnpm dlx` for both surfaces. Without an argument it writes; with `--check` it fails on drift.
- `README.md` — regenerated `github` variant: grouped tables (content pipeline / language workshop / workbench), ferralk and palamedes present, job strings and docs links straight from the registry. It stays where it was, above the standards-owned branding footer.
- `node/ferriki/README.md` — the `registry` variant: two plain-Markdown lines, no HTML, because npmjs.com renders this file and strips the markup the full block uses. The platform sidecars under `node/platforms/` stay without a block; they are install-time artifacts, not a product surface.
- `.github/workflows/ci.yml` — the `lint` job (which already sets up Node and pnpm) runs `--check`, so a hand-edited block fails the build. No new job, nothing added to the Rust matrix.
- `node/scripts/check-docs-contract.mjs` — additionally holds the `ferramenta-family` markers in place, so a README cannot quietly lose the block in the offline lanes.
- `CONTRIBUTING.md` — a section on the block: how to regenerate, how to bump the pin when the registry changes, and why the text between the markers is not hand-edited. Added to the happy path.

Adopting a registry change is one commit here: bump `REGISTRY_PIN`, rerun the script, commit the regenerated blocks.

## Validation

- `node scripts/sync-readme-family.mjs --check` — passes; hand-editing a job string in the root README makes it exit 1, and rerunning without `--check` restores it (verified, then reverted).
- `node node/scripts/check-docs-contract.mjs` — passes; removing a marker makes it fail with the regenerate hint (verified, then reverted).
- `node node/scripts/check-docs-drift.mjs`, `node node/scripts/test-docs-drift.mjs` — pass (21/21); the new prose deliberately states no Node or Shiki version.
- From `node/`: `pnpm install --frozen-lockfile --ignore-scripts`, `pnpm run lint`, `pnpm run check:release` — pass.
- `node scripts/test-check-workflow-pins.mjs`, `node scripts/check-workflow-pins.mjs` — pass (61 references, all pinned).
- `cargo fmt --all --check` — passes; no Rust code changed.
- The generator was also exercised under pnpm 10.28.2, the version `node/package.json` pins for CI, to confirm the `&path:` git reference resolves there.

The native lanes (`test:ferriki-compat:*`, `check:packed-consumer`) were not run: they need a native build and nothing in this change touches the runtime.

## Issue

Refs #94 — the family block tasks; the tagline, badge and Node-floor tasks in that issue are untouched, so it stays open.
Refs sebastian-software/ferramenta#9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFZKSZqbtZnUT5tSVEB81M


---
_Generated by [Claude Code](https://claude.ai/code/session_01LFZKSZqbtZnUT5tSVEB81M)_