### PR TITLE
chore: apply @sebastian-software/standards v12

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Report a security vulnerability
+  - name: Report a security vulnerability by email
+    url: https://github.com/sebastian-software/ferriki/blob/main/SECURITY.md
+    about: Do not open a public issue. Email security@sebastian-software.de — this route always works, whatever the repository's settings are.
+  - name: Report a security vulnerability as a private advisory
     url: https://github.com/sebastian-software/ferriki/security/advisories/new
-    about: Do not open a public issue. Use "Report a vulnerability" on this repository's Security tab, or email security@sebastian-software.de.
+    about: Do not open a public issue. Works once private vulnerability reporting is enabled for this repository; otherwise use the email route above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,36 @@ jobs:
       - name: Verify every workflow action is pinned by commit SHA
         run: node scripts/check-workflow-pins.mjs
 
+  standards:
+    name: Standards drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: "Guard: agent step not yet completed for this PR"
+        run: test ! -f .standards/pending.json
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          package_json_file: node/package.json
+
+      - name: Set node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+
+      # This repository has no root package.json and therefore no lockfile to
+      # hold the CLI version, so the pin lives in the command and Renovate's
+      # custom manager in renovate.json moves it. An unpinned `dlx` would run
+      # whatever was published minutes ago, with this job's token.
+      #
+      # minimum-release-age=0 stays: pnpm 11 holds versions younger than 24h
+      # back, so a pin raised on the day of a standards release would not
+      # resolve at all without it.
+      - name: Check for standards drift
+        run: pnpm --config.minimum-release-age=0 dlx @sebastian-software/standards@0.9.0 check
+
   rust:
     runs-on: ubuntu-latest
     steps:

--- a/.repometa.json
+++ b/.repometa.json
@@ -1,6 +1,9 @@
 {
-  "standards": 9,
+  "standards": 12,
   "visibility": "oss",
   "since": 2026,
-  "platform": "github"
+  "platform": "github",
+  "workspaces": [
+    "node"
+  ]
 }

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -27,16 +27,15 @@ to protect the community and the project.
 
 ## Reporting
 
-Report unacceptable behavior privately rather than opening a public issue. Two
-routes are available:
+Report unacceptable behavior privately rather than opening a public issue, by
+email to **security@sebastian-software.de**.
 
-- **The repository maintainers**, through GitHub — for everyday reports about
-  behavior in project spaces.
-- **security@sebastian-software.de** — a private inbox at Sebastian Software
-  GmbH, independent of any individual repository maintainer. Use it when the
-  report concerns a maintainer, or whenever you would rather not write to the
-  maintainers directly. It is the same address as for security reports; conduct
-  reports sent there are handled confidentially as conduct reports.
+That is a private inbox at Sebastian Software GmbH, independent of any
+individual repository maintainer, so it also works when the report concerns a
+maintainer. It is the same address as for security reports; conduct reports sent
+there are handled confidentially as conduct reports. GitHub has no private
+message channel to a repository's maintainers, which is why this one address is
+the route rather than an unspecified "contact the maintainers".
 
 Reports are reviewed as promptly and confidentially as practical. Include links,
 dates, and relevant context, but no credentials and no data you are not allowed

--- a/node/.oxfmtrc.json
+++ b/node/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": ["dist", "**/dist", "coverage", "pnpm-lock.yaml", "CHANGELOG.md", ".standards/"]
+}

--- a/node/.prettierignore
+++ b/node/.prettierignore
@@ -1,0 +1,11 @@
+# Repository-local formatter ignores. The managed `.oxfmtrc.json` is owned by
+# @sebastian-software/standards and must not carry repository-specific entries,
+# so oxfmt picks these up through the `.prettierignore` it auto-discovers
+# (see changes/0005-oxfmt-ignore-patterns.md in the standards repository).
+
+# Mechanical mirror of Shiki and vscode-textmate. ADR 0003: never hand-edited,
+# so it is never reformatted either.
+compat/upstream/
+
+# Generated declaration output of `check:api` (tsconfig.api.json).
+.generated/

--- a/node/compat/harness/core-compat-manifest.mjs
+++ b/node/compat/harness/core-compat-manifest.mjs
@@ -1,84 +1,97 @@
 export const coreCompatSupportedTests = [
-  'compat/upstream/shiki/packages/core/test/core-sync.test.ts',
-  'compat/upstream/shiki/packages/core/test/core.test.ts',
-  'compat/upstream/shiki/packages/core/test/get-singleton.test.ts',
-  'compat/upstream/shiki/packages/shiki/test/alias.test.ts',
-  'compat/upstream/shiki/packages/shiki/test/astro.test.ts',
-  'compat/upstream/shiki/packages/shiki/test/bundle.test.ts',
-  'compat/upstream/shiki/packages/shiki/test/get-highlighter.test.ts',
-  'compat/upstream/shiki/packages/shiki/test/general.test.ts',
-  'compat/upstream/shiki/packages/shiki/test/injections.test.ts',
-]
+  "compat/upstream/shiki/packages/core/test/core-sync.test.ts",
+  "compat/upstream/shiki/packages/core/test/core.test.ts",
+  "compat/upstream/shiki/packages/core/test/get-singleton.test.ts",
+  "compat/upstream/shiki/packages/shiki/test/alias.test.ts",
+  "compat/upstream/shiki/packages/shiki/test/astro.test.ts",
+  "compat/upstream/shiki/packages/shiki/test/bundle.test.ts",
+  "compat/upstream/shiki/packages/shiki/test/get-highlighter.test.ts",
+  "compat/upstream/shiki/packages/shiki/test/general.test.ts",
+  "compat/upstream/shiki/packages/shiki/test/injections.test.ts",
+];
 
 export const coreCompatDeferredTests = [
   {
-    path: 'compat/upstream/shiki/packages/core/test/css-variables.test.ts',
-    reason: 'Shiki engine CSS-variable patching is outside the accepted native boundary; Ferriki registration and multi-theme contracts are covered by dedicated checks',
+    path: "compat/upstream/shiki/packages/core/test/css-variables.test.ts",
+    reason:
+      "Shiki engine CSS-variable patching is outside the accepted native boundary; Ferriki registration and multi-theme contracts are covered by dedicated checks",
     issue: 48,
   },
   {
-    path: 'compat/upstream/shiki/packages/core/test/tokens.test.ts',
-    reason: 'remaining upstream token snapshots and native projection edge cases are tracked in the Ferriki token contract',
+    path: "compat/upstream/shiki/packages/core/test/tokens.test.ts",
+    reason:
+      "remaining upstream token snapshots and native projection edge cases are tracked in the Ferriki token contract",
     issue: 47,
   },
   {
-    path: 'compat/upstream/shiki/packages/core/test/transformers.test.ts',
-    reason: 'upstream engine transformer fixtures are outside the native boundary; the JS facade contract is covered by check-ferriki-transformers',
+    path: "compat/upstream/shiki/packages/core/test/transformers.test.ts",
+    reason:
+      "upstream engine transformer fixtures are outside the native boundary; the JS facade contract is covered by check-ferriki-transformers",
     issue: 45,
   },
   {
-    path: 'compat/upstream/shiki/packages/shiki/test/ansi.test.ts',
-    reason: 'ANSI escape parsing is an explicit non-goal; Ferriki rejects terminal escape sequences before native execution',
+    path: "compat/upstream/shiki/packages/shiki/test/ansi.test.ts",
+    reason:
+      "ANSI escape parsing is an explicit non-goal; Ferriki rejects terminal escape sequences before native execution",
     issue: 48,
   },
   {
-    path: 'compat/upstream/shiki/packages/shiki/test/color-replacement.test.ts',
-    reason: 'the upstream bundle fixture exercises Shiki-only theme plumbing; Ferriki colorReplacements are validated by the native option contract',
+    path: "compat/upstream/shiki/packages/shiki/test/color-replacement.test.ts",
+    reason:
+      "the upstream bundle fixture exercises Shiki-only theme plumbing; Ferriki colorReplacements are validated by the native option contract",
     issue: 48,
   },
   {
-    path: 'compat/upstream/shiki/packages/shiki/test/css-variables.test.ts',
-    reason: 'the upstream helper fixture is outside the accepted native boundary; Ferriki CSS variables are covered by the multi-theme and registration contracts',
+    path: "compat/upstream/shiki/packages/shiki/test/css-variables.test.ts",
+    reason:
+      "the upstream helper fixture is outside the accepted native boundary; Ferriki CSS variables are covered by the multi-theme and registration contracts",
     issue: 48,
   },
   {
-    path: 'compat/upstream/shiki/packages/shiki/test/decorations.test.ts',
-    reason: 'upstream bundle decorations are exercised through the Ferriki JS facade contract',
+    path: "compat/upstream/shiki/packages/shiki/test/decorations.test.ts",
+    reason: "upstream bundle decorations are exercised through the Ferriki JS facade contract",
     issue: 45,
   },
   {
-    path: 'compat/upstream/shiki/packages/shiki/test/dist.test.ts',
-    reason: 'upstream distribution-file assertions do not describe the Ferriki package boundary; packed Ferriki artifacts have a separate consumer gate',
+    path: "compat/upstream/shiki/packages/shiki/test/dist.test.ts",
+    reason:
+      "upstream distribution-file assertions do not describe the Ferriki package boundary; packed Ferriki artifacts have a separate consumer gate",
     issue: 42,
   },
   {
-    path: 'compat/upstream/shiki/packages/shiki/test/grammar-state.test.ts',
-    reason: 'remaining upstream grammar-state snapshots and native stack parity are tracked in the Ferriki grammar-state contract',
+    path: "compat/upstream/shiki/packages/shiki/test/grammar-state.test.ts",
+    reason:
+      "remaining upstream grammar-state snapshots and native stack parity are tracked in the Ferriki grammar-state contract",
     issue: 47,
   },
   {
-    path: 'compat/upstream/shiki/packages/shiki/test/hast.test.ts',
-    reason: 'the upstream HAST fixture combines adapter-owned metadata with engine behavior; Ferriki HAST, decoration, and multi-theme contracts are covered by dedicated checks',
+    path: "compat/upstream/shiki/packages/shiki/test/hast.test.ts",
+    reason:
+      "the upstream HAST fixture combines adapter-owned metadata with engine behavior; Ferriki HAST, decoration, and multi-theme contracts are covered by dedicated checks",
     issue: 45,
   },
   {
-    path: 'compat/upstream/shiki/packages/shiki/test/shorthands-markdown.test.ts',
-    reason: 'Markdown shorthand expansion belongs to an optional adapter, not the Ferriki core product boundary',
+    path: "compat/upstream/shiki/packages/shiki/test/shorthands-markdown.test.ts",
+    reason:
+      "Markdown shorthand expansion belongs to an optional adapter, not the Ferriki core product boundary",
     issue: 42,
   },
   {
-    path: 'compat/upstream/shiki/packages/shiki/test/shorthands.test.ts',
-    reason: 'the upstream shorthand fixture asserts Shiki-specific adapter wording; Ferriki usage errors and native recovery are covered by the error contract',
+    path: "compat/upstream/shiki/packages/shiki/test/shorthands.test.ts",
+    reason:
+      "the upstream shorthand fixture asserts Shiki-specific adapter wording; Ferriki usage errors and native recovery are covered by the error contract",
     issue: 50,
   },
   {
-    path: 'compat/upstream/shiki/packages/shiki/test/theme-none.test.ts',
-    reason: 'Ferriki theme-none and dual-theme behavior is covered by the dedicated multi-theme contract rather than the upstream adapter fixture',
+    path: "compat/upstream/shiki/packages/shiki/test/theme-none.test.ts",
+    reason:
+      "Ferriki theme-none and dual-theme behavior is covered by the dedicated multi-theme contract rather than the upstream adapter fixture",
     issue: 43,
   },
   {
-    path: 'compat/upstream/shiki/packages/shiki/test/themes.test.ts',
-    reason: 'Ferriki multi-theme and defaultColor behavior is covered by the dedicated native contract with deterministic output assertions',
+    path: "compat/upstream/shiki/packages/shiki/test/themes.test.ts",
+    reason:
+      "Ferriki multi-theme and defaultColor behavior is covered by the dedicated native contract with deterministic output assertions",
     issue: 43,
   },
-]
+];

--- a/node/compat/harness/honest-alias.test.ts
+++ b/node/compat/harness/honest-alias.test.ts
@@ -1,15 +1,18 @@
-import { expect, it } from 'vitest'
+import { expect, it } from "vitest";
 
-it('routes every compatibility entry point through the Ferriki backend', async () => {
+it("routes every compatibility entry point through the Ferriki backend", async () => {
   const modules = await Promise.all([
-    import('shiki'),
-    import('shiki/core'),
-    import('shiki/bundle/full'),
-    import('@shikijs/engine-javascript'),
-    import('@shikijs/engine-oniguruma'),
-    import('@shikijs/engine-oniguruma/wasm-inlined'),
-  ])
+    import("shiki"),
+    import("shiki/core"),
+    import("shiki/bundle/full"),
+    import("@shikijs/engine-javascript"),
+    import("@shikijs/engine-oniguruma"),
+    import("@shikijs/engine-oniguruma/wasm-inlined"),
+  ]);
 
-  expect(modules).toHaveLength(6)
-  expect((globalThis as typeof globalThis & { __FERRIKI_COMPAT_NATIVE?: boolean }).__FERRIKI_COMPAT_NATIVE).toBe(true)
-})
+  expect(modules).toHaveLength(6);
+  expect(
+    (globalThis as typeof globalThis & { __FERRIKI_COMPAT_NATIVE?: boolean })
+      .__FERRIKI_COMPAT_NATIVE,
+  ).toBe(true);
+});

--- a/node/compat/harness/run-colorized-brackets-compat.mjs
+++ b/node/compat/harness/run-colorized-brackets-compat.mjs
@@ -1,26 +1,35 @@
-import { spawnSync } from 'node:child_process'
-import process from 'node:process'
+import { spawnSync } from "node:child_process";
+import process from "node:process";
 
 const files = [
-  'compat/upstream/shiki/packages/colorized-brackets/test/bracket-customization.test.ts',
-  'compat/upstream/shiki/packages/colorized-brackets/test/dual-themes.test.ts',
-  'compat/upstream/shiki/packages/colorized-brackets/test/explicit-trigger.test.ts',
-]
+  "compat/upstream/shiki/packages/colorized-brackets/test/bracket-customization.test.ts",
+  "compat/upstream/shiki/packages/colorized-brackets/test/dual-themes.test.ts",
+  "compat/upstream/shiki/packages/colorized-brackets/test/explicit-trigger.test.ts",
+];
 
-let exitCode = 0
+let exitCode = 0;
 
 for (const file of files) {
   const result = spawnSync(
-    'pnpm',
-    ['exec', 'vitest', file, '--run', '--pool', 'forks', '--poolOptions.forks.singleFork', '--no-file-parallelism', '--no-isolate'],
+    "pnpm",
+    [
+      "exec",
+      "vitest",
+      file,
+      "--run",
+      "--pool",
+      "forks",
+      "--poolOptions.forks.singleFork",
+      "--no-file-parallelism",
+      "--no-isolate",
+    ],
     {
-      stdio: 'inherit',
+      stdio: "inherit",
       env: process.env,
     },
-  )
+  );
 
-  if ((result.status ?? 1) !== 0)
-    exitCode = result.status ?? 1
+  if ((result.status ?? 1) !== 0) exitCode = result.status ?? 1;
 }
 
-process.exit(exitCode)
+process.exit(exitCode);

--- a/node/compat/harness/shiki-backend-entry.ts
+++ b/node/compat/harness/shiki-backend-entry.ts
@@ -1,11 +1,11 @@
-export * from '../../ferriki/index.mjs'
+export * from "../../ferriki/index.mjs";
 
 // This marker is test-harness state, not a public Ferriki export. Keeping it
 // here lets the honest-alias sentinel prove routing without widening the API.
 Object.assign(globalThis, {
   __FERRIKI_COMPAT_NATIVE: true,
   __FERRIKI_COMPAT_LEGACY_ANSI: true,
-})
+});
 
 // Keep legacy upstream ANSI snapshots runnable while the public Ferriki
 // contract rejects control sequences. This marker exists only in the mirror
@@ -15,15 +15,15 @@ Object.assign(globalThis, {
 // tests are being retired. Keep those names isolated to the test harness;
 // they are intentionally absent from Ferriki's public package exports.
 export function createJavaScriptRegexEngine(): { kind: string } {
-  return { kind: 'compatibility-only-native-engine' }
+  return { kind: "compatibility-only-native-engine" };
 }
 
 export function createOnigurumaEngine(): { kind: string } {
-  return { kind: 'compatibility-only-native-engine' }
+  return { kind: "compatibility-only-native-engine" };
 }
 
 export async function loadWasm(): Promise<never> {
-  throw new Error('Ferriki uses its native runtime; WASM loading is not supported.')
+  throw new Error("Ferriki uses its native runtime; WASM loading is not supported.");
 }
 
-export const wasmBinary = new Uint8Array()
+export const wasmBinary = new Uint8Array();

--- a/node/compat/vscode-textmate-paths.json
+++ b/node/compat/vscode-textmate-paths.json
@@ -1,8 +1,1 @@
-[
-  "LICENSE.md",
-  "README.md",
-  "ThirdPartyNotices.txt",
-  "package.json",
-  "src",
-  "test-cases"
-]
+["LICENSE.md", "README.md", "ThirdPartyNotices.txt", "package.json", "src", "test-cases"]

--- a/node/cspell.json
+++ b/node/cspell.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.2",
+  "ignorePaths": [".standards/"],
+  "words": ["forgejo", "lockfile", "oxfmt", "oxlint", "pnpm", "repometa"]
+}

--- a/node/eslint.config.js
+++ b/node/eslint.config.js
@@ -1,22 +1,36 @@
 // @ts-check
-import antfu from '@antfu/eslint-config'
+import antfu from "@antfu/eslint-config";
 
 export default antfu(
   {
-    type: 'lib',
+    type: "lib",
     pnpm: true,
+    // oxfmt is the formatter (@sebastian-software/standards owns the managed
+    // `.oxfmtrc.json` next to this file), so ESLint checks correctness only.
+    stylistic: false,
     ignores: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/*.d.mts',
-      'compat/upstream/**',
-      'pnpm-workspace.yaml',
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.d.mts",
+      "compat/upstream/**",
+      "pnpm-workspace.yaml",
+      // Seeded by `standards apply` for the org lint setup. Both import
+      // `eslint-config-setup`, which needs ESLint >= 10, while this workspace
+      // is on the ESLint 9 catalog entry it shares with the upstream mirror.
+      // Until that bump lands they are not the entry point, so they are not
+      // linted either.
+      "eslint.config.ts",
+      "oxlint.config.ts",
     ],
   },
   {
     rules: {
-      'no-restricted-syntax': 'off',
-      'ts/no-invalid-this': 'off',
+      "no-restricted-syntax": "off",
+      "ts/no-invalid-this": "off",
+      // Owned by oxfmt, which sorts package.json keys and lowercases numeric
+      // literals; keeping the lint rules on would fight the formatter.
+      "jsonc/sort-keys": "off",
+      "unicorn/number-literal-case": "off",
     },
   },
-)
+);

--- a/node/eslint.config.ts
+++ b/node/eslint.config.ts
@@ -1,0 +1,16 @@
+import { getEslintConfig } from "eslint-config-setup";
+
+const config = await getEslintConfig({ node: true, oxlint: true });
+
+config.unshift({
+  ignores: [
+    "**/dist/**",
+    "coverage/**",
+    "node_modules/**",
+    "pnpm-lock.yaml",
+    "**/*.json",
+    "**/*.md",
+  ],
+});
+
+export default config;

--- a/node/ferriki/README.md
+++ b/node/ferriki/README.md
@@ -22,47 +22,47 @@ ship the bundled main-package binary instead.
 Use a shorthand for one-off highlighting:
 
 ```js
-import { codeToHtml } from 'ferriki'
+import { codeToHtml } from "ferriki";
 
 const html = await codeToHtml('console.log("Hello")', {
-  lang: 'javascript',
-  theme: 'nord',
-})
+  lang: "javascript",
+  theme: "nord",
+});
 ```
 
 Reuse a highlighter when highlighting multiple snippets:
 
 ```js
-import { createHighlighter } from 'ferriki'
+import { createHighlighter } from "ferriki";
 
 using highlighter = await createHighlighter({
-  langs: ['javascript', 'markdown'],
-  themes: ['nord'],
-})
+  langs: ["javascript", "markdown"],
+  themes: ["nord"],
+});
 
-const html = highlighter.codeToHtml('const answer = 42', {
-  lang: 'javascript',
-  theme: 'nord',
-})
+const html = highlighter.codeToHtml("const answer = 42", {
+  lang: "javascript",
+  theme: "nord",
+});
 
-const tokens = highlighter.codeToTokens('# Hello', {
-  lang: 'markdown',
-  theme: 'nord',
-})
+const tokens = highlighter.codeToTokens("# Hello", {
+  lang: "markdown",
+  theme: "nord",
+});
 ```
 
 For Ardo-style light/dark output, pass an ordered theme map. With
 `defaultColor: false`, Ferriki emits CSS variables for every theme:
 
 ```js
-const html = highlighter.codeToHtml('const answer = 42', {
-  lang: 'typescript',
+const html = highlighter.codeToHtml("const answer = 42", {
+  lang: "typescript",
   themes: {
-    light: 'vitesse-light',
-    dark: 'vitesse-dark',
+    light: "vitesse-light",
+    dark: "vitesse-dark",
   },
   defaultColor: false,
-})
+});
 ```
 
 `codeToHast` returns the same highlighted output as a HAST root. Languages
@@ -74,23 +74,29 @@ before they cross the native boundary:
 
 ```js
 using custom = await createHighlighter({
-  langs: [{
-    name: 'todo',
-    scopeName: 'source.todo',
-    aliases: ['todos'],
-    patterns: [{ match: '\\bTODO\\b', name: 'keyword.todo' }],
-  }],
-  themes: [{
-    name: 'todo-theme',
-    type: 'light',
-    fg: '#111111',
-    bg: '#ffffff',
-    settings: [{
-      scope: 'keyword.todo',
-      settings: { foreground: '#ff00aa', fontStyle: 'bold' },
-    }],
-  }],
-})
+  langs: [
+    {
+      name: "todo",
+      scopeName: "source.todo",
+      aliases: ["todos"],
+      patterns: [{ match: "\\bTODO\\b", name: "keyword.todo" }],
+    },
+  ],
+  themes: [
+    {
+      name: "todo-theme",
+      type: "light",
+      fg: "#111111",
+      bg: "#ffffff",
+      settings: [
+        {
+          scope: "keyword.todo",
+          settings: { foreground: "#ff00aa", fontStyle: "bold" },
+        },
+      ],
+    },
+  ],
+});
 ```
 
 Synchronous factories accept already-resolved names and registrations only;
@@ -152,6 +158,7 @@ Licensed under either of
 at your option.
 
 <!-- ferramenta-family:start -->
+
 **ferriki** is part of the [Ferramenta](https://ferramenta.dev) family — Rust-native developer tools that keep the APIs the ecosystem already knows.
 
 Siblings: [ferroni](https://sebastian-software.github.io/ferroni/) · [ferromark](https://sebastian-software.github.io/ferromark/) · [ferrolex](https://github.com/sebastian-software/ferrolex) · [ferrocat](https://ferrocat.dev) · [palamedes](https://palamedes.dev) · [ferrovia](https://github.com/sebastian-software/ferrovia) · [ferralk](https://github.com/sebastian-software/ferralk) · [ferrugo](https://github.com/sebastian-software/ferrugo).

--- a/node/ferriki/index.d.mts
+++ b/node/ferriki/index.d.mts
@@ -1,2 +1,2 @@
 /* This file is generated from src/api.mts. Run `pnpm run build` after changing the source. */
-export * from './src/api.mjs'
+export * from "./src/api.mjs";

--- a/node/ferriki/index.mjs
+++ b/node/ferriki/index.mjs
@@ -1,2 +1,2 @@
 /* This file is generated from src/index.mjs. Run `pnpm run build` after changing the source. */
-export * from './src/index.mjs'
+export * from "./src/index.mjs";

--- a/node/ferriki/native.d.mts
+++ b/node/ferriki/native.d.mts
@@ -1,23 +1,23 @@
 export interface FerrikiNativeHighlighter {
-  loadStandardTheme: (themeId: string) => boolean
-  loadStandardGrammar: (language: string) => string | undefined
-  loadCustomTheme: (registrationJson: string) => boolean
-  loadCustomGrammar: (registrationJson: string) => string | undefined
-  resolveGrammarScope: (language: string) => string | undefined
-  getLoadedGrammarScopes: () => string[]
-  getLoadedLanguages: () => string[]
-  codeToTokens: (code: string, optionsJson: string) => string
-  codeToTokensWithThemes: (code: string, optionsJson: string) => string
-  codeToHast: (code: string, optionsJson: string) => string
-  codeToHtml: (code: string, optionsJson: string) => string
-  dispose: () => void
+  loadStandardTheme: (themeId: string) => boolean;
+  loadStandardGrammar: (language: string) => string | undefined;
+  loadCustomTheme: (registrationJson: string) => boolean;
+  loadCustomGrammar: (registrationJson: string) => string | undefined;
+  resolveGrammarScope: (language: string) => string | undefined;
+  getLoadedGrammarScopes: () => string[];
+  getLoadedLanguages: () => string[];
+  codeToTokens: (code: string, optionsJson: string) => string;
+  codeToTokensWithThemes: (code: string, optionsJson: string) => string;
+  codeToHast: (code: string, optionsJson: string) => string;
+  codeToHtml: (code: string, optionsJson: string) => string;
+  dispose: () => void;
 }
 
 export interface FerrikiNativeBinding {
-  ferrikiVersion: () => string
-  createHighlighter: (optionsJson: string) => FerrikiNativeHighlighter
-  FerrikiHighlighter: abstract new (...args: never[]) => FerrikiNativeHighlighter
+  ferrikiVersion: () => string;
+  createHighlighter: (optionsJson: string) => FerrikiNativeHighlighter;
+  FerrikiHighlighter: abstract new (...args: never[]) => FerrikiNativeHighlighter;
 }
 
-export declare function loadFerrikiNativeBinding(): FerrikiNativeBinding
-export declare function tryLoadFerrikiNativeBinding(): FerrikiNativeBinding | undefined
+export declare function loadFerrikiNativeBinding(): FerrikiNativeBinding;
+export declare function tryLoadFerrikiNativeBinding(): FerrikiNativeBinding | undefined;

--- a/node/ferriki/native.mjs
+++ b/node/ferriki/native.mjs
@@ -1,9 +1,9 @@
-import { createRequire } from 'node:module'
-import { dirname, join } from 'node:path'
-import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-import { formatFerrikiPlatformMatrix, resolveFerrikiPlatformTarget } from './platforms.mjs'
+import { formatFerrikiPlatformMatrix, resolveFerrikiPlatformTarget } from "./platforms.mjs";
 
 // Every candidate says how it must be resolved. The sidecar is a package
 // specifier that Node resolves from node_modules, whatever its scope; the rest
@@ -12,48 +12,50 @@ import { formatFerrikiPlatformMatrix, resolveFerrikiPlatformTarget } from './pla
 function nativeCandidates(target, here) {
   return [
     { package: `${target.packageName}/ferriki.node` },
-    { file: join(here, 'dist', target.binaryName) },
-    { file: join(here, 'dist', 'ferriki.node') },
-    { file: join(here, 'ferriki.node') },
-  ]
+    { file: join(here, "dist", target.binaryName) },
+    { file: join(here, "dist", "ferriki.node") },
+    { file: join(here, "ferriki.node") },
+  ];
 }
 
 export function loadFerrikiNativeBinding() {
-  const require = createRequire(import.meta.url)
-  const here = dirname(fileURLToPath(import.meta.url))
-  const target = resolveFerrikiPlatformTarget()
-  const candidates = target ? nativeCandidates(target, here) : []
-  const errors = []
+  const require = createRequire(import.meta.url);
+  const here = dirname(fileURLToPath(import.meta.url));
+  const target = resolveFerrikiPlatformTarget();
+  const candidates = target ? nativeCandidates(target, here) : [];
+  const errors = [];
   for (const candidate of candidates) {
-    const label = candidate.package ?? candidate.file
+    const label = candidate.package ?? candidate.file;
     try {
-      const resolved = candidate.package ? require.resolve(candidate.package) : candidate.file
-      return require(resolved)
-    }
-    catch (error) {
-      errors.push(`${label}: ${String(error)}`)
+      const resolved = candidate.package ? require.resolve(candidate.package) : candidate.file;
+      return require(resolved);
+    } catch (error) {
+      errors.push(`${label}: ${String(error)}`);
     }
   }
   if (!target) {
-    throw new Error([
-      `[ferriki] Unsupported target ${process.platform}-${process.arch}${process.platform === 'linux' ? ' (musl or unknown libc)' : ''}.`,
-      `Supported targets: ${formatFerrikiPlatformMatrix()}.`,
-      'Ferriki currently supports GNU libc on Linux; musl/Alpine requires a separately tested target.',
-    ].join('\n'))
+    throw new Error(
+      [
+        `[ferriki] Unsupported target ${process.platform}-${process.arch}${process.platform === "linux" ? " (musl or unknown libc)" : ""}.`,
+        `Supported targets: ${formatFerrikiPlatformMatrix()}.`,
+        "Ferriki currently supports GNU libc on Linux; musl/Alpine requires a separately tested target.",
+      ].join("\n"),
+    );
   }
-  throw new Error([
-    `[ferriki] No native binary for ${target.id}.`,
-    `Install the optional platform package ${target.packageName} or use a supported target.`,
-    'Tried:',
-    ...errors.map(e => `- ${e}`),
-  ].join('\n'))
+  throw new Error(
+    [
+      `[ferriki] No native binary for ${target.id}.`,
+      `Install the optional platform package ${target.packageName} or use a supported target.`,
+      "Tried:",
+      ...errors.map((e) => `- ${e}`),
+    ].join("\n"),
+  );
 }
 
 export function tryLoadFerrikiNativeBinding() {
   try {
-    return loadFerrikiNativeBinding()
-  }
-  catch {
-    return undefined
+    return loadFerrikiNativeBinding();
+  } catch {
+    return undefined;
   }
 }

--- a/node/ferriki/package.json
+++ b/node/ferriki/package.json
@@ -1,41 +1,25 @@
 {
   "name": "ferriki",
-  "type": "module",
   "version": "0.3.0",
   "description": "Shiki-compatible syntax highlighting with a leaner Rust core and Node bindings",
-  "license": "MIT OR Apache-2.0",
+  "keywords": [
+    "highlighter",
+    "napi",
+    "rust",
+    "shiki",
+    "syntax-highlighting",
+    "textmate"
+  ],
   "homepage": "https://github.com/sebastian-software/ferriki#readme",
+  "bugs": {
+    "url": "https://github.com/sebastian-software/ferriki/issues"
+  },
+  "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sebastian-software/ferriki.git",
     "directory": "node/ferriki"
   },
-  "bugs": {
-    "url": "https://github.com/sebastian-software/ferriki/issues"
-  },
-  "keywords": [
-    "shiki",
-    "syntax-highlighting",
-    "highlighter",
-    "textmate",
-    "rust",
-    "napi"
-  ],
-  "sideEffects": false,
-  "exports": {
-    ".": {
-      "types": "./index.d.mts",
-      "default": "./index.mjs"
-    },
-    "./native": {
-      "types": "./native.d.mts",
-      "default": "./native.mjs"
-    },
-    "./package.json": "./package.json"
-  },
-  "main": "./index.mjs",
-  "module": "./index.mjs",
-  "types": "./index.d.mts",
   "files": [
     "CHANGELOG.md",
     "LICENSE-APACHE",
@@ -52,13 +36,29 @@
     "src/index.mjs",
     "transformers.mjs"
   ],
-  "engines": {
-    "node": ">=22.13.0"
+  "type": "module",
+  "sideEffects": false,
+  "main": "./index.mjs",
+  "module": "./index.mjs",
+  "types": "./index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./index.d.mts",
+      "default": "./index.mjs"
+    },
+    "./native": {
+      "types": "./native.d.mts",
+      "default": "./native.mjs"
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "node ./scripts/build-wrapper.mjs && node ./scripts/verify-wrapper.mjs",
     "dev": "node ./scripts/build-wrapper.mjs && node ./scripts/verify-wrapper.mjs",
     "build:native": "node ./scripts/build-native.mjs"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:types"
   },
   "optionalDependencies": {
     "ferriki-darwin-arm64": "0.3.0",
@@ -67,7 +67,7 @@
     "ferriki-linux-x64-gnu": "0.3.0",
     "ferriki-win32-x64-msvc": "0.3.0"
   },
-  "devDependencies": {
-    "@types/node": "catalog:types"
+  "engines": {
+    "node": ">=22.13.0"
   }
 }

--- a/node/ferriki/platforms.mjs
+++ b/node/ferriki/platforms.mjs
@@ -1,43 +1,77 @@
-import process from 'node:process'
+import process from "node:process";
 
 /**
  * The release workflow publishes these five GNU/MSVC targets as optional
  * sidecar packages. The map is deliberately shared by the loader, docs, and
  * CI so a new target cannot be documented accidentally.
  */
-export const FERRIKI_NODE_MIN_VERSION = '22.13.0'
+export const FERRIKI_NODE_MIN_VERSION = "22.13.0";
 
 export const FERRIKI_PLATFORM_TARGETS = Object.freeze([
-  Object.freeze({ id: 'linux-x64-gnu', platform: 'linux', arch: 'x64', libc: 'gnu', packageName: 'ferriki-linux-x64-gnu', binaryName: 'ferriki.linux-x64.node' }),
-  Object.freeze({ id: 'linux-arm64-gnu', platform: 'linux', arch: 'arm64', libc: 'gnu', packageName: 'ferriki-linux-arm64-gnu', binaryName: 'ferriki.linux-arm64.node' }),
-  Object.freeze({ id: 'darwin-arm64', platform: 'darwin', arch: 'arm64', packageName: 'ferriki-darwin-arm64', binaryName: 'ferriki.darwin-arm64.node' }),
-  Object.freeze({ id: 'darwin-x64', platform: 'darwin', arch: 'x64', packageName: 'ferriki-darwin-x64', binaryName: 'ferriki.darwin-x64.node' }),
-  Object.freeze({ id: 'win32-x64-msvc', platform: 'win32', arch: 'x64', libc: 'msvc', packageName: 'ferriki-win32-x64-msvc', binaryName: 'ferriki.win32-x64.node' }),
-])
+  Object.freeze({
+    id: "linux-x64-gnu",
+    platform: "linux",
+    arch: "x64",
+    libc: "gnu",
+    packageName: "ferriki-linux-x64-gnu",
+    binaryName: "ferriki.linux-x64.node",
+  }),
+  Object.freeze({
+    id: "linux-arm64-gnu",
+    platform: "linux",
+    arch: "arm64",
+    libc: "gnu",
+    packageName: "ferriki-linux-arm64-gnu",
+    binaryName: "ferriki.linux-arm64.node",
+  }),
+  Object.freeze({
+    id: "darwin-arm64",
+    platform: "darwin",
+    arch: "arm64",
+    packageName: "ferriki-darwin-arm64",
+    binaryName: "ferriki.darwin-arm64.node",
+  }),
+  Object.freeze({
+    id: "darwin-x64",
+    platform: "darwin",
+    arch: "x64",
+    packageName: "ferriki-darwin-x64",
+    binaryName: "ferriki.darwin-x64.node",
+  }),
+  Object.freeze({
+    id: "win32-x64-msvc",
+    platform: "win32",
+    arch: "x64",
+    libc: "msvc",
+    packageName: "ferriki-win32-x64-msvc",
+    binaryName: "ferriki.win32-x64.node",
+  }),
+]);
 
 export function detectLinuxLibc(platform = process.platform) {
-  if (platform !== 'linux')
-    return undefined
+  if (platform !== "linux") return undefined;
   try {
-    return process.report?.getReport?.().header?.glibcVersionRuntime ? 'gnu' : 'musl'
-  }
-  catch {
-    return 'unknown'
+    return process.report?.getReport?.().header?.glibcVersionRuntime ? "gnu" : "musl";
+  } catch {
+    return "unknown";
   }
 }
 
 export function resolveFerrikiPlatformTarget({
   platform = process.platform,
   arch = process.arch,
-  libc = platform === 'win32' ? 'msvc' : detectLinuxLibc(platform),
+  libc = platform === "win32" ? "msvc" : detectLinuxLibc(platform),
 } = {}) {
-  return FERRIKI_PLATFORM_TARGETS.find(target => target.platform === platform
-    && target.arch === arch
-    && (target.libc === undefined || target.libc === libc))
+  return FERRIKI_PLATFORM_TARGETS.find(
+    (target) =>
+      target.platform === platform &&
+      target.arch === arch &&
+      (target.libc === undefined || target.libc === libc),
+  );
 }
 
 export function formatFerrikiPlatformMatrix() {
-  return FERRIKI_PLATFORM_TARGETS
-    .map(target => `${target.id} (Node >= ${FERRIKI_NODE_MIN_VERSION})`)
-    .join(', ')
+  return FERRIKI_PLATFORM_TARGETS.map(
+    (target) => `${target.id} (Node >= ${FERRIKI_NODE_MIN_VERSION})`,
+  ).join(", ");
 }

--- a/node/ferriki/public-api-types.typecheck.ts
+++ b/node/ferriki/public-api-types.typecheck.ts
@@ -1,39 +1,39 @@
-import type {
-  HighlighterOptions,
-  HighlighterSyncOptions,
-  HighlightOptions,
-} from './index.d.mts'
+import type { HighlighterOptions, HighlighterSyncOptions, HighlightOptions } from "./index.d.mts";
 
 const highlighterOptions: HighlighterOptions = {
-  langs: ['typescript'],
-  themes: ['nord'],
-  langAlias: { ts: 'typescript' },
-}
+  langs: ["typescript"],
+  themes: ["nord"],
+  langAlias: { ts: "typescript" },
+};
 
 const syncOptions: HighlighterSyncOptions = {
-  langs: ['typescript'],
-  themes: ['nord'],
-}
+  langs: ["typescript"],
+  themes: ["nord"],
+};
 
 const highlightOptions: HighlightOptions = {
-  lang: 'typescript',
-  theme: 'nord',
+  lang: "typescript",
+  theme: "nord",
   defaultColor: false,
-}
+};
 
-void highlighterOptions
-void syncOptions
-void highlightOptions
+void highlighterOptions;
+void syncOptions;
+void highlightOptions;
 
 // @ts-expect-error Unsupported factory options must not pass through the public type.
-const unsupportedFactoryOption: HighlighterOptions = { engine: 'javascript' }
+const unsupportedFactoryOption: HighlighterOptions = { engine: "javascript" };
 
 // @ts-expect-error Unsupported synchronous factory options must not pass through the public type.
-const unsupportedSyncOption: HighlighterSyncOptions = { wasmBinary: new Uint8Array() }
+const unsupportedSyncOption: HighlighterSyncOptions = { wasmBinary: new Uint8Array() };
 
-// @ts-expect-error Unsupported highlight options must not pass through the public type.
-const unsupportedHighlightOption: HighlightOptions = { lang: 'typescript', theme: 'nord', unknown: true }
+const unsupportedHighlightOption: HighlightOptions = {
+  lang: "typescript",
+  theme: "nord",
+  // @ts-expect-error Unsupported highlight options must not pass through the public type.
+  unknown: true,
+};
 
-void unsupportedFactoryOption
-void unsupportedSyncOption
-void unsupportedHighlightOption
+void unsupportedFactoryOption;
+void unsupportedSyncOption;
+void unsupportedHighlightOption;

--- a/node/ferriki/scripts/build-native.mjs
+++ b/node/ferriki/scripts/build-native.mjs
@@ -1,110 +1,106 @@
-import { spawnSync } from 'node:child_process'
-import { cp, stat } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
-import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import { spawnSync } from "node:child_process";
+import { cp, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '..')
-const repoRoot = join(pkgDir, '..', '..')
-const manifestPath = join(repoRoot, 'crates', 'ferriki-core', 'Cargo.toml')
-const addonOut = join(pkgDir, 'ferriki.node')
-const distAddonOut = join(pkgDir, 'dist', 'ferriki.node')
-const rustTarget = process.env.FERRIKI_RUST_TARGET
-let platformTarget = process.env.FERRIKI_PLATFORM_TARGET
-let platformId = process.env.FERRIKI_PLATFORM_ID
+const pkgDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = join(pkgDir, "..", "..");
+const manifestPath = join(repoRoot, "crates", "ferriki-core", "Cargo.toml");
+const addonOut = join(pkgDir, "ferriki.node");
+const distAddonOut = join(pkgDir, "dist", "ferriki.node");
+const rustTarget = process.env.FERRIKI_RUST_TARGET;
+let platformTarget = process.env.FERRIKI_PLATFORM_TARGET;
+let platformId = process.env.FERRIKI_PLATFORM_ID;
 
 if (!platformId && rustTarget) {
   platformId = {
-    'x86_64-unknown-linux-gnu': 'linux-x64-gnu',
-    'aarch64-unknown-linux-gnu': 'linux-arm64-gnu',
-    'aarch64-apple-darwin': 'darwin-arm64',
-    'x86_64-apple-darwin': 'darwin-x64',
-    'x86_64-pc-windows-msvc': 'win32-x64-msvc',
-  }[rustTarget]
+    "x86_64-unknown-linux-gnu": "linux-x64-gnu",
+    "aarch64-unknown-linux-gnu": "linux-arm64-gnu",
+    "aarch64-apple-darwin": "darwin-arm64",
+    "x86_64-apple-darwin": "darwin-x64",
+    "x86_64-pc-windows-msvc": "win32-x64-msvc",
+  }[rustTarget];
 }
 
 if (!platformTarget && rustTarget) {
   platformTarget = {
-    'x86_64-unknown-linux-gnu': 'linux-x64',
-    'aarch64-unknown-linux-gnu': 'linux-arm64',
-    'aarch64-apple-darwin': 'darwin-arm64',
-    'x86_64-apple-darwin': 'darwin-x64',
-    'x86_64-pc-windows-msvc': 'win32-x64',
-  }[rustTarget]
+    "x86_64-unknown-linux-gnu": "linux-x64",
+    "aarch64-unknown-linux-gnu": "linux-arm64",
+    "aarch64-apple-darwin": "darwin-arm64",
+    "x86_64-apple-darwin": "darwin-x64",
+    "x86_64-pc-windows-msvc": "win32-x64",
+  }[rustTarget];
 }
 
-if (!platformTarget)
-  platformTarget = `${process.platform}-${process.arch}`
+if (!platformTarget) platformTarget = `${process.platform}-${process.arch}`;
 
 if (!platformTarget) {
-  throw new Error(`[ferriki] Unsupported FERRIKI_RUST_TARGET: ${rustTarget}`)
+  throw new Error(`[ferriki] Unsupported FERRIKI_RUST_TARGET: ${rustTarget}`);
 }
 
-const platformAddonOut = join(pkgDir, 'dist', `ferriki.${platformTarget}.node`)
+const platformAddonOut = join(pkgDir, "dist", `ferriki.${platformTarget}.node`);
 const sidecarAddonOut = platformId
-  ? join(repoRoot, 'node', 'platforms', platformId, 'ferriki.node')
-  : undefined
-const syncAssetsScript = join(pkgDir, 'scripts', 'sync-standard-assets.mjs')
-const cargoArgs = ['build', '--release', '--manifest-path', manifestPath]
+  ? join(repoRoot, "node", "platforms", platformId, "ferriki.node")
+  : undefined;
+const syncAssetsScript = join(pkgDir, "scripts", "sync-standard-assets.mjs");
+const cargoArgs = ["build", "--release", "--manifest-path", manifestPath];
 
-if (rustTarget)
-  cargoArgs.push('--target', rustTarget)
+if (rustTarget) cargoArgs.push("--target", rustTarget);
 
-const cargo = spawnSync('cargo', cargoArgs, {
+const cargo = spawnSync("cargo", cargoArgs, {
   cwd: repoRoot,
-  stdio: 'inherit',
-})
+  stdio: "inherit",
+});
 
-if (cargo.status !== 0)
-  process.exit(cargo.status ?? 1)
+if (cargo.status !== 0) process.exit(cargo.status ?? 1);
 
-const dylibName = process.platform === 'darwin'
-  ? 'libferriki_core.dylib'
-  : process.platform === 'linux'
-    ? 'libferriki_core.so'
-    : 'ferriki_core.dll'
+const dylibName =
+  process.platform === "darwin"
+    ? "libferriki_core.dylib"
+    : process.platform === "linux"
+      ? "libferriki_core.so"
+      : "ferriki_core.dll";
 
 const candidates = [
-  join(repoRoot, 'target', ...(rustTarget ? [rustTarget] : []), 'release', dylibName),
-]
+  join(repoRoot, "target", ...(rustTarget ? [rustTarget] : []), "release", dylibName),
+];
 
-let selectedInput = null
+let selectedInput = null;
 for (const candidate of candidates) {
   try {
-    const info = await stat(candidate)
+    const info = await stat(candidate);
     if (info.isFile()) {
-      selectedInput = candidate
-      break
+      selectedInput = candidate;
+      break;
     }
-  }
-  catch (error) {
-    void error
+  } catch (error) {
+    void error;
   }
 }
 
 if (!selectedInput) {
-  throw new Error([
-    '[ferriki] Could not locate compiled native artifact.',
-    'Expected one of:',
-    ...candidates.map(i => `- ${i}`),
-  ].join('\n'))
+  throw new Error(
+    [
+      "[ferriki] Could not locate compiled native artifact.",
+      "Expected one of:",
+      ...candidates.map((i) => `- ${i}`),
+    ].join("\n"),
+  );
 }
 
-await cp(selectedInput, addonOut)
-await cp(selectedInput, distAddonOut)
-await cp(selectedInput, platformAddonOut)
-if (sidecarAddonOut)
-  await cp(selectedInput, sidecarAddonOut)
-const syncAssets = spawnSync('node', [syncAssetsScript], {
+await cp(selectedInput, addonOut);
+await cp(selectedInput, distAddonOut);
+await cp(selectedInput, platformAddonOut);
+if (sidecarAddonOut) await cp(selectedInput, sidecarAddonOut);
+const syncAssets = spawnSync("node", [syncAssetsScript], {
   cwd: repoRoot,
-  stdio: 'inherit',
-})
+  stdio: "inherit",
+});
 
-if (syncAssets.status !== 0)
-  process.exit(syncAssets.status ?? 1)
+if (syncAssets.status !== 0) process.exit(syncAssets.status ?? 1);
 
-console.log(`[ferriki] Native addon ready: ${addonOut}`)
-console.log(`[ferriki] Bundled native addon ready: ${distAddonOut}`)
-console.log(`[ferriki] Platform addon ready: ${platformAddonOut}`)
-if (sidecarAddonOut)
-  console.log(`[ferriki] Sidecar addon ready: ${sidecarAddonOut}`)
+console.log(`[ferriki] Native addon ready: ${addonOut}`);
+console.log(`[ferriki] Bundled native addon ready: ${distAddonOut}`);
+console.log(`[ferriki] Platform addon ready: ${platformAddonOut}`);
+if (sidecarAddonOut) console.log(`[ferriki] Sidecar addon ready: ${sidecarAddonOut}`);

--- a/node/ferriki/scripts/build-wrapper.mjs
+++ b/node/ferriki/scripts/build-wrapper.mjs
@@ -1,43 +1,49 @@
-import { spawnSync } from 'node:child_process'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
-import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import { spawnSync } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-const packageDir = dirname(dirname(fileURLToPath(import.meta.url)))
-const nodeRoot = dirname(packageDir)
-const generatedDir = join(nodeRoot, '.generated', 'ferriki')
-const generatedTypes = join(generatedDir, 'api.d.mts')
-const sourceTypes = join(packageDir, 'src', 'api.d.mts')
+import { WRAPPER_RUNTIME, WRAPPER_TYPES } from "./wrapper-contents.mjs";
 
-await mkdir(generatedDir, { recursive: true })
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const nodeRoot = dirname(packageDir);
+const generatedDir = join(nodeRoot, ".generated", "ferriki");
+const generatedTypes = join(generatedDir, "api.d.mts");
+const sourceTypes = join(packageDir, "src", "api.d.mts");
 
-const typecheck = spawnSync('pnpm', [
-  'exec',
-  'tsc',
-  '--project',
-  join(nodeRoot, 'tsconfig.api.json'),
-], {
+await mkdir(generatedDir, { recursive: true });
+
+const typecheck = spawnSync(
+  "pnpm",
+  ["exec", "tsc", "--project", join(nodeRoot, "tsconfig.api.json")],
+  {
+    cwd: nodeRoot,
+    shell: process.platform === "win32",
+    stdio: "inherit",
+  },
+);
+
+if (typecheck.error) throw typecheck.error;
+if (typecheck.status !== 0) process.exit(typecheck.status ?? 1);
+
+await writeFile(sourceTypes, await readFile(generatedTypes));
+
+// tsc indents its declaration output with four spaces. The checked-in copy is
+// formatted by oxfmt through the workspace's managed `.oxfmtrc.json`, so format
+// it here rather than let `format:check` fail on a generated file.
+const format = spawnSync("pnpm", ["exec", "oxfmt", "--write", sourceTypes], {
   cwd: nodeRoot,
-  shell: process.platform === 'win32',
-  stdio: 'inherit',
-})
+  shell: process.platform === "win32",
+  stdio: "inherit",
+});
 
-if (typecheck.error)
-  throw typecheck.error
-if (typecheck.status !== 0)
-  process.exit(typecheck.status ?? 1)
+if (format.error) throw format.error;
+if (format.status !== 0) process.exit(format.status ?? 1);
 
-await writeFile(sourceTypes, await readFile(generatedTypes))
-await writeFile(join(packageDir, 'index.mjs'), [
-  '/* This file is generated from src/index.mjs. Run `pnpm run build` after changing the source. */',
-  'export * from \'./src/index.mjs\'',
-  '',
-].join('\n'))
-await writeFile(join(packageDir, 'index.d.mts'), [
-  '/* This file is generated from src/api.mts. Run `pnpm run build` after changing the source. */',
-  'export * from \'./src/api.mjs\'',
-  '',
-].join('\n'))
+// The two wrapper files are written in the shape oxfmt produces, so that
+// `pnpm run build` and `pnpm run format:check` agree on them.
+await writeFile(join(packageDir, "index.mjs"), WRAPPER_RUNTIME);
+await writeFile(join(packageDir, "index.d.mts"), WRAPPER_TYPES);
 
-console.log('[ferriki] Generated public runtime wrapper and declarations')
+console.log("[ferriki] Generated public runtime wrapper and declarations");

--- a/node/ferriki/scripts/sync-standard-assets.mjs
+++ b/node/ferriki/scripts/sync-standard-assets.mjs
@@ -1,53 +1,52 @@
-import { cp, rm, stat } from 'node:fs/promises'
-import { dirname, join, resolve } from 'node:path'
-import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import { cp, rm, stat } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '..')
-const repoRoot = join(pkgDir, '..', '..')
-const args = parseArgs(process.argv.slice(2))
-const sourceDir = args.sourceDir ?? join(repoRoot, 'assets', 'shiki')
-const destDir = args.destDir ?? join(pkgDir, 'assets', 'shiki')
+const pkgDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = join(pkgDir, "..", "..");
+const args = parseArgs(process.argv.slice(2));
+const sourceDir = args.sourceDir ?? join(repoRoot, "assets", "shiki");
+const destDir = args.destDir ?? join(pkgDir, "assets", "shiki");
 
 if (!(await existsDir(sourceDir))) {
-  console.log(`[ferriki] No standard asset catalog found at ${sourceDir}; skipping package asset sync.`)
-  process.exit(0)
+  console.log(
+    `[ferriki] No standard asset catalog found at ${sourceDir}; skipping package asset sync.`,
+  );
+  process.exit(0);
 }
 
-await rm(destDir, { recursive: true, force: true })
-await cp(sourceDir, destDir, { recursive: true })
-console.log(`[ferriki] Standard assets synced: ${sourceDir} -> ${destDir}`)
+await rm(destDir, { recursive: true, force: true });
+await cp(sourceDir, destDir, { recursive: true });
+console.log(`[ferriki] Standard assets synced: ${sourceDir} -> ${destDir}`);
 
 function parseArgs(argv) {
-  let sourceDir
-  let destDir
+  let sourceDir;
+  let destDir;
 
   for (let i = 0; i < argv.length; i += 2) {
-    const flag = argv[i]
-    const value = argv[i + 1]
+    const flag = argv[i];
+    const value = argv[i + 1];
     if (!value) {
-      throw new Error(`Missing value for ${flag}`)
+      throw new Error(`Missing value for ${flag}`);
     }
-    if (flag === '--source-dir') {
-      sourceDir = resolve(value)
-    }
-    else if (flag === '--dest-dir') {
-      destDir = resolve(value)
-    }
-    else {
-      throw new Error(`Unknown flag: ${flag}`)
+    if (flag === "--source-dir") {
+      sourceDir = resolve(value);
+    } else if (flag === "--dest-dir") {
+      destDir = resolve(value);
+    } else {
+      throw new Error(`Unknown flag: ${flag}`);
     }
   }
 
-  return { sourceDir, destDir }
+  return { sourceDir, destDir };
 }
 
 async function existsDir(dir) {
   try {
-    const info = await stat(dir)
-    return info.isDirectory()
-  }
-  catch {
-    return false
+    const info = await stat(dir);
+    return info.isDirectory();
+  } catch {
+    return false;
   }
 }

--- a/node/ferriki/scripts/verify-wrapper.mjs
+++ b/node/ferriki/scripts/verify-wrapper.mjs
@@ -1,35 +1,27 @@
-import { access, readFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { access, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const pkgDir = dirname(dirname(fileURLToPath(import.meta.url)))
+import { WRAPPER_RUNTIME, WRAPPER_TYPES } from "./wrapper-contents.mjs";
+
+const pkgDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const required = [
-  join(pkgDir, 'index.mjs'),
-  join(pkgDir, 'native.mjs'),
-  join(pkgDir, 'src', 'api.mts'),
-  join(pkgDir, 'src', 'api.d.mts'),
-  join(pkgDir, 'src', 'index.mjs'),
-]
+  join(pkgDir, "index.mjs"),
+  join(pkgDir, "native.mjs"),
+  join(pkgDir, "src", "api.mts"),
+  join(pkgDir, "src", "api.d.mts"),
+  join(pkgDir, "src", "index.mjs"),
+];
 
-for (const file of required)
-  await access(file)
-
-const expectedRuntime = [
-  '/* This file is generated from src/index.mjs. Run `pnpm run build` after changing the source. */',
-  'export * from \'./src/index.mjs\'',
-  '',
-].join('\n')
-const expectedTypes = [
-  '/* This file is generated from src/api.mts. Run `pnpm run build` after changing the source. */',
-  'export * from \'./src/api.mjs\'',
-  '',
-].join('\n')
+for (const file of required) await access(file);
 
 const [runtime, types] = await Promise.all([
-  readFile(join(pkgDir, 'index.mjs'), 'utf8'),
-  readFile(join(pkgDir, 'index.d.mts'), 'utf8'),
-])
+  readFile(join(pkgDir, "index.mjs"), "utf8"),
+  readFile(join(pkgDir, "index.d.mts"), "utf8"),
+]);
 
-if (runtime !== expectedRuntime || types !== expectedTypes) {
-  throw new Error('Generated Ferriki wrapper files are stale; run `pnpm run build` and commit the result.')
+if (runtime !== WRAPPER_RUNTIME || types !== WRAPPER_TYPES) {
+  throw new Error(
+    "Generated Ferriki wrapper files are stale; run `pnpm run build` and commit the result.",
+  );
 }

--- a/node/ferriki/scripts/wrapper-contents.mjs
+++ b/node/ferriki/scripts/wrapper-contents.mjs
@@ -1,0 +1,14 @@
+// The exact bytes of the two generated wrapper files. `build-wrapper.mjs`
+// writes them and `verify-wrapper.mjs` checks them, so the shape lives here
+// once instead of in two copies that can drift apart.
+export const WRAPPER_RUNTIME = [
+  "/* This file is generated from src/index.mjs. Run `pnpm run build` after changing the source. */",
+  'export * from "./src/index.mjs";',
+  "",
+].join("\n");
+
+export const WRAPPER_TYPES = [
+  "/* This file is generated from src/api.mts. Run `pnpm run build` after changing the source. */",
+  'export * from "./src/api.mjs";',
+  "",
+].join("\n");

--- a/node/ferriki/src/api.d.mts
+++ b/node/ferriki/src/api.d.mts
@@ -1,203 +1,250 @@
 export interface LanguageRegistration {
-    name: string;
-    scopeName: string;
-    displayName?: string;
-    aliases?: readonly string[];
-    patterns?: readonly unknown[];
-    repository?: Readonly<Record<string, unknown>>;
-    injections?: Readonly<Record<string, unknown>>;
-    injectionSelector?: string;
-    fileTypes?: readonly string[];
-    firstLineMatch?: string;
-    embeddedLangs?: readonly string[];
-    embeddedLanguages?: readonly string[];
-    embeddedLangsLazy?: readonly string[];
-    injectTo?: readonly string[];
-    balancedBracketSelectors?: readonly string[];
-    unbalancedBracketSelectors?: readonly string[];
-    foldingStopMarker?: string;
-    foldingStartMarker?: string;
+  name: string;
+  scopeName: string;
+  displayName?: string;
+  aliases?: readonly string[];
+  patterns?: readonly unknown[];
+  repository?: Readonly<Record<string, unknown>>;
+  injections?: Readonly<Record<string, unknown>>;
+  injectionSelector?: string;
+  fileTypes?: readonly string[];
+  firstLineMatch?: string;
+  embeddedLangs?: readonly string[];
+  embeddedLanguages?: readonly string[];
+  embeddedLangsLazy?: readonly string[];
+  injectTo?: readonly string[];
+  balancedBracketSelectors?: readonly string[];
+  unbalancedBracketSelectors?: readonly string[];
+  foldingStopMarker?: string;
+  foldingStartMarker?: string;
 }
 export interface ThemeRegistration {
-    name: string;
-    type?: 'dark' | 'light' | string;
-    fg?: string;
-    bg?: string;
-    settings?: readonly unknown[];
-    tokenColors?: readonly unknown[];
-    colors?: Readonly<Record<string, string>>;
-    include?: string;
-    displayName?: string;
-    $schema?: string;
-    semanticHighlighting?: boolean;
-    semanticTokenColors?: Readonly<Record<string, string>>;
+  name: string;
+  type?: "dark" | "light" | string;
+  fg?: string;
+  bg?: string;
+  settings?: readonly unknown[];
+  tokenColors?: readonly unknown[];
+  colors?: Readonly<Record<string, string>>;
+  include?: string;
+  displayName?: string;
+  $schema?: string;
+  semanticHighlighting?: boolean;
+  semanticTokenColors?: Readonly<Record<string, string>>;
 }
 export type LanguageInput = string | LanguageRegistration;
 export type ThemeInput = string | ThemeRegistration;
-export type SyncRegistrationInput<T> = T | {
-    default: SyncRegistrationInput<T>;
-} | readonly SyncRegistrationInput<T>[];
-export type RegistrationInput<T> = SyncRegistrationInput<T> | PromiseLike<RegistrationInput<T>> | (() => RegistrationInput<T>);
+export type SyncRegistrationInput<T> =
+  | T
+  | {
+      default: SyncRegistrationInput<T>;
+    }
+  | readonly SyncRegistrationInput<T>[];
+export type RegistrationInput<T> =
+  | SyncRegistrationInput<T>
+  | PromiseLike<RegistrationInput<T>>
+  | (() => RegistrationInput<T>);
 export interface HighlighterOptions {
-    langs?: readonly RegistrationInput<LanguageInput>[];
-    themes?: readonly RegistrationInput<ThemeInput>[];
-    langAlias?: Readonly<Record<string, string>>;
-    transformers?: readonly ShikiTransformer[];
+  langs?: readonly RegistrationInput<LanguageInput>[];
+  themes?: readonly RegistrationInput<ThemeInput>[];
+  langAlias?: Readonly<Record<string, string>>;
+  transformers?: readonly ShikiTransformer[];
 }
 export interface HighlighterSyncOptions {
-    langs?: readonly SyncRegistrationInput<LanguageInput>[];
-    themes?: readonly SyncRegistrationInput<ThemeInput>[];
-    langAlias?: Readonly<Record<string, string>>;
-    transformers?: readonly ShikiTransformer[];
+  langs?: readonly SyncRegistrationInput<LanguageInput>[];
+  themes?: readonly SyncRegistrationInput<ThemeInput>[];
+  langAlias?: Readonly<Record<string, string>>;
+  transformers?: readonly ShikiTransformer[];
 }
 export interface HighlightOptions {
-    lang: LanguageInput;
-    theme?: ThemeInput;
-    themes?: Readonly<Record<string, ThemeInput>>;
-    defaultColor?: string | false;
-    cssVariablePrefix?: string;
-    includeExplanation?: boolean | 'scopeName' | 'tokenType';
-    grammarState?: GrammarState;
-    mergeWhitespaces?: boolean;
-    mergeSameStyleTokens?: boolean;
-    rootStyle?: string | false;
-    tabindex?: string | number | false | null;
-    tokenizeMaxLineLength?: number;
-    tokenizeTimeLimit?: number;
-    structure?: 'classic' | 'inline';
-    meta?: Readonly<Record<string, unknown>>;
-    data?: Readonly<Record<string, unknown>>;
-    transformers?: readonly ShikiTransformer[];
-    decorations?: readonly DecorationItem[];
+  lang: LanguageInput;
+  theme?: ThemeInput;
+  themes?: Readonly<Record<string, ThemeInput>>;
+  defaultColor?: string | false;
+  cssVariablePrefix?: string;
+  includeExplanation?: boolean | "scopeName" | "tokenType";
+  grammarState?: GrammarState;
+  mergeWhitespaces?: boolean;
+  mergeSameStyleTokens?: boolean;
+  rootStyle?: string | false;
+  tabindex?: string | number | false | null;
+  tokenizeMaxLineLength?: number;
+  tokenizeTimeLimit?: number;
+  structure?: "classic" | "inline";
+  meta?: Readonly<Record<string, unknown>>;
+  data?: Readonly<Record<string, unknown>>;
+  transformers?: readonly ShikiTransformer[];
+  decorations?: readonly DecorationItem[];
 }
 export interface ThemedToken {
-    content: string;
-    offset: number;
-    htmlAttrs?: Readonly<Record<string, string>>;
-    color?: string;
-    fontStyle?: number;
-    type?: number;
-    htmlStyle?: Readonly<Record<string, string>>;
-    variants?: Readonly<Record<string, {
+  content: string;
+  offset: number;
+  htmlAttrs?: Readonly<Record<string, string>>;
+  color?: string;
+  fontStyle?: number;
+  type?: number;
+  htmlStyle?: Readonly<Record<string, string>>;
+  variants?: Readonly<
+    Record<
+      string,
+      {
         color?: string;
         fontStyle?: number;
-    }>>;
-    explanation?: readonly ThemedTokenExplanation[];
+      }
+    >
+  >;
+  explanation?: readonly ThemedTokenExplanation[];
 }
 export interface ThemedTokenScopeExplanation {
-    scopeName: string;
+  scopeName: string;
 }
 export interface ThemedTokenExplanation {
-    content: string;
-    scopes: readonly ThemedTokenScopeExplanation[];
+  content: string;
+  scopes: readonly ThemedTokenScopeExplanation[];
 }
 export interface GrammarState {
-    readonly version: 1;
-    readonly lang: string;
-    readonly theme: string;
-    readonly themes: readonly string[];
-    readonly scopes: readonly string[];
-    /** Opaque serialized source context used to continue tokenization. */
-    readonly source: string;
+  readonly version: 1;
+  readonly lang: string;
+  readonly theme: string;
+  readonly themes: readonly string[];
+  readonly scopes: readonly string[];
+  /** Opaque serialized source context used to continue tokenization. */
+  readonly source: string;
 }
 export interface TokensResult {
-    tokens: ThemedToken[][];
-    fg: string;
-    bg: string;
-    themeName: string;
-    rootStyle?: string;
-    grammarState?: GrammarState;
+  tokens: ThemedToken[][];
+  fg: string;
+  bg: string;
+  themeName: string;
+  rootStyle?: string;
+  grammarState?: GrammarState;
 }
 export interface HastText {
-    type: 'text';
-    value: string;
+  type: "text";
+  value: string;
 }
 export interface HastElement {
-    type: 'element';
-    tagName: string;
-    properties: Record<string, unknown>;
-    children: HastNode[];
+  type: "element";
+  tagName: string;
+  properties: Record<string, unknown>;
+  children: HastNode[];
 }
 export interface HastRoot {
-    type: 'root';
-    children: HastNode[];
+  type: "root";
+  children: HastNode[];
 }
 export type HastNode = HastRoot | HastElement | HastText;
 export interface DecorationItem {
-    start: number | {
+  start:
+    | number
+    | {
         line: number;
         character: number;
-    };
-    end: number | {
+      };
+  end:
+    | number
+    | {
         line: number;
         character: number;
-    };
-    tagName?: string;
-    properties?: Record<string, unknown>;
-    transform?: (element: HastElement, type: 'wrapper' | 'line' | 'token') => HastElement | void;
-    alwaysWrap?: boolean;
+      };
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  transform?: (element: HastElement, type: "wrapper" | "line" | "token") => HastElement | void;
+  alwaysWrap?: boolean;
 }
 export interface ShikiTransformerContextCommon {
-    meta: Record<string, unknown>;
-    options: HighlightOptions;
-    codeToHast: (code: string, options: HighlightOptions) => HastRoot;
-    codeToTokens: (code: string, options: HighlightOptions) => TokensResult;
+  meta: Record<string, unknown>;
+  options: HighlightOptions;
+  codeToHast: (code: string, options: HighlightOptions) => HastRoot;
+  codeToTokens: (code: string, options: HighlightOptions) => TokensResult;
 }
 export interface ShikiTransformerContext extends ShikiTransformerContextCommon {
-    readonly source: string;
-    readonly tokens: ThemedToken[][];
-    readonly root: HastRoot;
-    readonly pre: HastElement;
-    readonly code: HastElement;
-    readonly lines: HastElement[];
-    readonly structure: HighlightOptions['structure'];
-    addClassToHast: (hast: HastElement, className: string | string[]) => HastElement;
+  readonly source: string;
+  readonly tokens: ThemedToken[][];
+  readonly root: HastRoot;
+  readonly pre: HastElement;
+  readonly code: HastElement;
+  readonly lines: HastElement[];
+  readonly structure: HighlightOptions["structure"];
+  addClassToHast: (hast: HastElement, className: string | string[]) => HastElement;
 }
 export interface ShikiTransformer {
-    name?: string;
-    enforce?: 'pre' | 'post';
-    preprocess?: (this: ShikiTransformerContextCommon, code: string, options: HighlightOptions) => string | void;
-    tokens?: (this: ShikiTransformerContextCommon & {
-        readonly source: string;
-    }, tokens: ThemedToken[][]) => ThemedToken[][] | void;
-    root?: (this: ShikiTransformerContext, hast: HastRoot) => HastRoot | void;
-    pre?: (this: ShikiTransformerContext, hast: HastElement) => HastElement | void;
-    code?: (this: ShikiTransformerContext, hast: HastElement) => HastElement | void;
-    line?: (this: ShikiTransformerContext, hast: HastElement, line: number) => HastElement | void;
-    span?: (this: ShikiTransformerContext, hast: HastElement, line: number, col: number, lineElement: HastElement, token: ThemedToken) => HastElement | void;
-    postprocess?: (this: ShikiTransformerContextCommon, html: string, options: HighlightOptions) => string | void;
+  name?: string;
+  enforce?: "pre" | "post";
+  preprocess?: (
+    this: ShikiTransformerContextCommon,
+    code: string,
+    options: HighlightOptions,
+  ) => string | void;
+  tokens?: (
+    this: ShikiTransformerContextCommon & {
+      readonly source: string;
+    },
+    tokens: ThemedToken[][],
+  ) => ThemedToken[][] | void;
+  root?: (this: ShikiTransformerContext, hast: HastRoot) => HastRoot | void;
+  pre?: (this: ShikiTransformerContext, hast: HastElement) => HastElement | void;
+  code?: (this: ShikiTransformerContext, hast: HastElement) => HastElement | void;
+  line?: (this: ShikiTransformerContext, hast: HastElement, line: number) => HastElement | void;
+  span?: (
+    this: ShikiTransformerContext,
+    hast: HastElement,
+    line: number,
+    col: number,
+    lineElement: HastElement,
+    token: ThemedToken,
+  ) => HastElement | void;
+  postprocess?: (
+    this: ShikiTransformerContextCommon,
+    html: string,
+    options: HighlightOptions,
+  ) => string | void;
 }
 export interface Highlighter {
-    codeToHtml: (code: string, options: HighlightOptions) => string;
-    codeToHast: (code: string, options: HighlightOptions) => HastRoot;
-    codeToTokens: (code: string, options: HighlightOptions) => TokensResult;
-    codeToTokensBase: (code: string, options: HighlightOptions) => ThemedToken[][];
-    codeToTokensWithThemes: (code: string, options: HighlightOptions) => ThemedToken[][];
-    getLastGrammarState: {
-        (code: string, options: HighlightOptions): GrammarState;
-        (element: ThemedToken[][] | HastRoot): GrammarState | undefined;
-    };
-    getLoadedLanguages: () => string[];
-    getLoadedThemes: () => string[];
-    loadLanguage: (...languages: RegistrationInput<LanguageInput>[]) => Promise<void>;
-    loadLanguageSync: (...languages: SyncRegistrationInput<LanguageInput>[]) => void;
-    loadTheme: (...themes: RegistrationInput<ThemeInput>[]) => Promise<void>;
-    loadThemeSync: (...themes: SyncRegistrationInput<ThemeInput>[]) => void;
-    resolveLangAlias: (language: string) => string;
-    dispose: () => void;
-    [Symbol.dispose]: () => void;
+  codeToHtml: (code: string, options: HighlightOptions) => string;
+  codeToHast: (code: string, options: HighlightOptions) => HastRoot;
+  codeToTokens: (code: string, options: HighlightOptions) => TokensResult;
+  codeToTokensBase: (code: string, options: HighlightOptions) => ThemedToken[][];
+  codeToTokensWithThemes: (code: string, options: HighlightOptions) => ThemedToken[][];
+  getLastGrammarState: {
+    (code: string, options: HighlightOptions): GrammarState;
+    (element: ThemedToken[][] | HastRoot): GrammarState | undefined;
+  };
+  getLoadedLanguages: () => string[];
+  getLoadedThemes: () => string[];
+  loadLanguage: (...languages: RegistrationInput<LanguageInput>[]) => Promise<void>;
+  loadLanguageSync: (...languages: SyncRegistrationInput<LanguageInput>[]) => void;
+  loadTheme: (...themes: RegistrationInput<ThemeInput>[]) => Promise<void>;
+  loadThemeSync: (...themes: SyncRegistrationInput<ThemeInput>[]) => void;
+  resolveLangAlias: (language: string) => string;
+  dispose: () => void;
+  [Symbol.dispose]: () => void;
 }
-export type FerrikiErrorCode = 'ERR_USAGE' | 'ERR_UNSUPPORTED' | 'ERR_NATIVE_LOAD' | 'ERR_ASSET' | 'ERR_RESOURCE_LIMIT' | 'ERR_INTERNAL';
+export type FerrikiErrorCode =
+  | "ERR_USAGE"
+  | "ERR_UNSUPPORTED"
+  | "ERR_NATIVE_LOAD"
+  | "ERR_ASSET"
+  | "ERR_RESOURCE_LIMIT"
+  | "ERR_INTERNAL";
 export declare class ShikiError extends Error {
-    readonly code: FerrikiErrorCode;
-    constructor(message: string, code?: FerrikiErrorCode, options?: {
-        cause?: unknown;
-    });
+  readonly code: FerrikiErrorCode;
+  constructor(
+    message: string,
+    code?: FerrikiErrorCode,
+    options?: {
+      cause?: unknown;
+    },
+  );
 }
 export declare class FerrikiError extends ShikiError {
-    constructor(message: string, code?: FerrikiErrorCode, options?: {
-        cause?: unknown;
-    });
+  constructor(
+    message: string,
+    code?: FerrikiErrorCode,
+    options?: {
+      cause?: unknown;
+    },
+  );
 }
 /** Version of the bundled native core, or undefined when no platform binary loads. */
 export declare function ferrikiVersion(): string | undefined;
@@ -209,29 +256,72 @@ export declare function createShikiPrimitive(options?: HighlighterSyncOptions): 
 export declare function getSingletonHighlighter(options?: HighlighterOptions): Promise<Highlighter>;
 export declare const getSingletonHighlighterCore: typeof getSingletonHighlighter;
 export declare function codeToHtml(code: string, options: HighlightOptions): Promise<string>;
-export declare function codeToHtml(highlighter: Highlighter, code: string, options: HighlightOptions): string;
+export declare function codeToHtml(
+  highlighter: Highlighter,
+  code: string,
+  options: HighlightOptions,
+): string;
 export declare function codeToHast(code: string, options: HighlightOptions): Promise<HastRoot>;
-export declare function codeToHast(highlighter: Highlighter, code: string, options: HighlightOptions): HastRoot;
-export declare function codeToTokens(code: string, options: HighlightOptions): Promise<TokensResult>;
-export declare function codeToTokens(highlighter: Highlighter, code: string, options: HighlightOptions): TokensResult;
-export declare function codeToTokensBase(code: string, options: HighlightOptions): Promise<ThemedToken[][]>;
-export declare function codeToTokensBase(highlighter: Highlighter, code: string, options: HighlightOptions): ThemedToken[][];
-export declare function codeToTokensWithThemes(code: string, options: HighlightOptions): Promise<ThemedToken[][]>;
-export declare function codeToTokensWithThemes(highlighter: Highlighter, code: string, options: HighlightOptions): ThemedToken[][];
-export declare function getLastGrammarState(code: string, options: HighlightOptions): Promise<GrammarState>;
-export declare function getLastGrammarState(highlighter: Highlighter, code: string, options: HighlightOptions): GrammarState;
-export declare function getLastGrammarState(highlighter: Highlighter, element: ThemedToken[][] | HastRoot): GrammarState | undefined;
+export declare function codeToHast(
+  highlighter: Highlighter,
+  code: string,
+  options: HighlightOptions,
+): HastRoot;
+export declare function codeToTokens(
+  code: string,
+  options: HighlightOptions,
+): Promise<TokensResult>;
+export declare function codeToTokens(
+  highlighter: Highlighter,
+  code: string,
+  options: HighlightOptions,
+): TokensResult;
+export declare function codeToTokensBase(
+  code: string,
+  options: HighlightOptions,
+): Promise<ThemedToken[][]>;
+export declare function codeToTokensBase(
+  highlighter: Highlighter,
+  code: string,
+  options: HighlightOptions,
+): ThemedToken[][];
+export declare function codeToTokensWithThemes(
+  code: string,
+  options: HighlightOptions,
+): Promise<ThemedToken[][]>;
+export declare function codeToTokensWithThemes(
+  highlighter: Highlighter,
+  code: string,
+  options: HighlightOptions,
+): ThemedToken[][];
+export declare function getLastGrammarState(
+  code: string,
+  options: HighlightOptions,
+): Promise<GrammarState>;
+export declare function getLastGrammarState(
+  highlighter: Highlighter,
+  code: string,
+  options: HighlightOptions,
+): GrammarState;
+export declare function getLastGrammarState(
+  highlighter: Highlighter,
+  element: ThemedToken[][] | HastRoot,
+): GrammarState | undefined;
 export interface CssVariablesThemeOptions {
-    name?: string;
-    type?: 'dark' | 'light' | string;
-    variableDefaults?: {
-        foreground?: string;
-        background?: string;
-    };
+  name?: string;
+  type?: "dark" | "light" | string;
+  variableDefaults?: {
+    foreground?: string;
+    background?: string;
+  };
 }
-export declare function createCssVariablesTheme(options?: CssVariablesThemeOptions): ThemeRegistration;
+export declare function createCssVariablesTheme(
+  options?: CssVariablesThemeOptions,
+): ThemeRegistration;
 export declare function hastToHtml(tree: HastRoot | HastElement): string;
-export declare const bundledLanguages: Readonly<Record<string, () => Promise<LanguageRegistration[]>>>;
+export declare const bundledLanguages: Readonly<
+  Record<string, () => Promise<LanguageRegistration[]>>
+>;
 export declare const bundledThemes: Readonly<Record<string, () => Promise<ThemeRegistration>>>;
 export declare const bundledLanguagesAlias: Readonly<Record<string, string>>;
 export type BundledLanguage = keyof typeof bundledLanguages;

--- a/node/ferriki/src/api.mts
+++ b/node/ferriki/src/api.mts
@@ -1,312 +1,336 @@
 export interface LanguageRegistration {
-  name: string
-  scopeName: string
-  displayName?: string
-  aliases?: readonly string[]
-  patterns?: readonly unknown[]
-  repository?: Readonly<Record<string, unknown>>
-  injections?: Readonly<Record<string, unknown>>
-  injectionSelector?: string
-  fileTypes?: readonly string[]
-  firstLineMatch?: string
-  embeddedLangs?: readonly string[]
-  embeddedLanguages?: readonly string[]
-  embeddedLangsLazy?: readonly string[]
-  injectTo?: readonly string[]
-  balancedBracketSelectors?: readonly string[]
-  unbalancedBracketSelectors?: readonly string[]
-  foldingStopMarker?: string
-  foldingStartMarker?: string
+  name: string;
+  scopeName: string;
+  displayName?: string;
+  aliases?: readonly string[];
+  patterns?: readonly unknown[];
+  repository?: Readonly<Record<string, unknown>>;
+  injections?: Readonly<Record<string, unknown>>;
+  injectionSelector?: string;
+  fileTypes?: readonly string[];
+  firstLineMatch?: string;
+  embeddedLangs?: readonly string[];
+  embeddedLanguages?: readonly string[];
+  embeddedLangsLazy?: readonly string[];
+  injectTo?: readonly string[];
+  balancedBracketSelectors?: readonly string[];
+  unbalancedBracketSelectors?: readonly string[];
+  foldingStopMarker?: string;
+  foldingStartMarker?: string;
 }
 
 export interface ThemeRegistration {
-  name: string
-  type?: 'dark' | 'light' | string
-  fg?: string
-  bg?: string
-  settings?: readonly unknown[]
-  tokenColors?: readonly unknown[]
-  colors?: Readonly<Record<string, string>>
-  include?: string
-  displayName?: string
-  $schema?: string
-  semanticHighlighting?: boolean
-  semanticTokenColors?: Readonly<Record<string, string>>
+  name: string;
+  type?: "dark" | "light" | string;
+  fg?: string;
+  bg?: string;
+  settings?: readonly unknown[];
+  tokenColors?: readonly unknown[];
+  colors?: Readonly<Record<string, string>>;
+  include?: string;
+  displayName?: string;
+  $schema?: string;
+  semanticHighlighting?: boolean;
+  semanticTokenColors?: Readonly<Record<string, string>>;
 }
 
-export type LanguageInput = string | LanguageRegistration
-export type ThemeInput = string | ThemeRegistration
-export type SyncRegistrationInput<T>
-  = | T
-    | { default: SyncRegistrationInput<T> }
-    | readonly SyncRegistrationInput<T>[]
-export type RegistrationInput<T>
-  = | SyncRegistrationInput<T>
-    | PromiseLike<RegistrationInput<T>>
-    | (() => RegistrationInput<T>)
+export type LanguageInput = string | LanguageRegistration;
+export type ThemeInput = string | ThemeRegistration;
+export type SyncRegistrationInput<T> =
+  | T
+  | { default: SyncRegistrationInput<T> }
+  | readonly SyncRegistrationInput<T>[];
+export type RegistrationInput<T> =
+  | SyncRegistrationInput<T>
+  | PromiseLike<RegistrationInput<T>>
+  | (() => RegistrationInput<T>);
 
 export interface HighlighterOptions {
-  langs?: readonly RegistrationInput<LanguageInput>[]
-  themes?: readonly RegistrationInput<ThemeInput>[]
-  langAlias?: Readonly<Record<string, string>>
-  transformers?: readonly ShikiTransformer[]
+  langs?: readonly RegistrationInput<LanguageInput>[];
+  themes?: readonly RegistrationInput<ThemeInput>[];
+  langAlias?: Readonly<Record<string, string>>;
+  transformers?: readonly ShikiTransformer[];
 }
 
 export interface HighlighterSyncOptions {
-  langs?: readonly SyncRegistrationInput<LanguageInput>[]
-  themes?: readonly SyncRegistrationInput<ThemeInput>[]
-  langAlias?: Readonly<Record<string, string>>
-  transformers?: readonly ShikiTransformer[]
+  langs?: readonly SyncRegistrationInput<LanguageInput>[];
+  themes?: readonly SyncRegistrationInput<ThemeInput>[];
+  langAlias?: Readonly<Record<string, string>>;
+  transformers?: readonly ShikiTransformer[];
 }
 
 export interface HighlightOptions {
-  lang: LanguageInput
-  theme?: ThemeInput
-  themes?: Readonly<Record<string, ThemeInput>>
-  defaultColor?: string | false
-  cssVariablePrefix?: string
-  includeExplanation?: boolean | 'scopeName' | 'tokenType'
-  grammarState?: GrammarState
-  mergeWhitespaces?: boolean
-  mergeSameStyleTokens?: boolean
-  rootStyle?: string | false
-  tabindex?: string | number | false | null
-  tokenizeMaxLineLength?: number
-  tokenizeTimeLimit?: number
-  structure?: 'classic' | 'inline'
-  meta?: Readonly<Record<string, unknown>>
-  data?: Readonly<Record<string, unknown>>
-  transformers?: readonly ShikiTransformer[]
-  decorations?: readonly DecorationItem[]
+  lang: LanguageInput;
+  theme?: ThemeInput;
+  themes?: Readonly<Record<string, ThemeInput>>;
+  defaultColor?: string | false;
+  cssVariablePrefix?: string;
+  includeExplanation?: boolean | "scopeName" | "tokenType";
+  grammarState?: GrammarState;
+  mergeWhitespaces?: boolean;
+  mergeSameStyleTokens?: boolean;
+  rootStyle?: string | false;
+  tabindex?: string | number | false | null;
+  tokenizeMaxLineLength?: number;
+  tokenizeTimeLimit?: number;
+  structure?: "classic" | "inline";
+  meta?: Readonly<Record<string, unknown>>;
+  data?: Readonly<Record<string, unknown>>;
+  transformers?: readonly ShikiTransformer[];
+  decorations?: readonly DecorationItem[];
 }
 
 export interface ThemedToken {
-  content: string
-  offset: number
-  htmlAttrs?: Readonly<Record<string, string>>
-  color?: string
-  fontStyle?: number
-  type?: number
-  htmlStyle?: Readonly<Record<string, string>>
-  variants?: Readonly<Record<string, {
-    color?: string
-    fontStyle?: number
-  }>>
-  explanation?: readonly ThemedTokenExplanation[]
+  content: string;
+  offset: number;
+  htmlAttrs?: Readonly<Record<string, string>>;
+  color?: string;
+  fontStyle?: number;
+  type?: number;
+  htmlStyle?: Readonly<Record<string, string>>;
+  variants?: Readonly<
+    Record<
+      string,
+      {
+        color?: string;
+        fontStyle?: number;
+      }
+    >
+  >;
+  explanation?: readonly ThemedTokenExplanation[];
 }
 
 export interface ThemedTokenScopeExplanation {
-  scopeName: string
+  scopeName: string;
 }
 
 export interface ThemedTokenExplanation {
-  content: string
-  scopes: readonly ThemedTokenScopeExplanation[]
+  content: string;
+  scopes: readonly ThemedTokenScopeExplanation[];
 }
 
 export interface GrammarState {
-  readonly version: 1
-  readonly lang: string
-  readonly theme: string
-  readonly themes: readonly string[]
-  readonly scopes: readonly string[]
+  readonly version: 1;
+  readonly lang: string;
+  readonly theme: string;
+  readonly themes: readonly string[];
+  readonly scopes: readonly string[];
   /** Opaque serialized source context used to continue tokenization. */
-  readonly source: string
+  readonly source: string;
 }
 
 export interface TokensResult {
-  tokens: ThemedToken[][]
-  fg: string
-  bg: string
-  themeName: string
-  rootStyle?: string
-  grammarState?: GrammarState
+  tokens: ThemedToken[][];
+  fg: string;
+  bg: string;
+  themeName: string;
+  rootStyle?: string;
+  grammarState?: GrammarState;
 }
 
 export interface HastText {
-  type: 'text'
-  value: string
+  type: "text";
+  value: string;
 }
 
 export interface HastElement {
-  type: 'element'
-  tagName: string
-  properties: Record<string, unknown>
-  children: HastNode[]
+  type: "element";
+  tagName: string;
+  properties: Record<string, unknown>;
+  children: HastNode[];
 }
 
 export interface HastRoot {
-  type: 'root'
-  children: HastNode[]
+  type: "root";
+  children: HastNode[];
 }
 
-export type HastNode = HastRoot | HastElement | HastText
+export type HastNode = HastRoot | HastElement | HastText;
 
 export interface DecorationItem {
-  start: number | { line: number, character: number }
-  end: number | { line: number, character: number }
-  tagName?: string
-  properties?: Record<string, unknown>
-  transform?: (element: HastElement, type: 'wrapper' | 'line' | 'token') => HastElement | void
-  alwaysWrap?: boolean
+  start: number | { line: number; character: number };
+  end: number | { line: number; character: number };
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  transform?: (element: HastElement, type: "wrapper" | "line" | "token") => HastElement | void;
+  alwaysWrap?: boolean;
 }
 
 export interface ShikiTransformerContextCommon {
-  meta: Record<string, unknown>
-  options: HighlightOptions
-  codeToHast: (code: string, options: HighlightOptions) => HastRoot
-  codeToTokens: (code: string, options: HighlightOptions) => TokensResult
+  meta: Record<string, unknown>;
+  options: HighlightOptions;
+  codeToHast: (code: string, options: HighlightOptions) => HastRoot;
+  codeToTokens: (code: string, options: HighlightOptions) => TokensResult;
 }
 
 export interface ShikiTransformerContext extends ShikiTransformerContextCommon {
-  readonly source: string
-  readonly tokens: ThemedToken[][]
-  readonly root: HastRoot
-  readonly pre: HastElement
-  readonly code: HastElement
-  readonly lines: HastElement[]
-  readonly structure: HighlightOptions['structure']
-  addClassToHast: (hast: HastElement, className: string | string[]) => HastElement
+  readonly source: string;
+  readonly tokens: ThemedToken[][];
+  readonly root: HastRoot;
+  readonly pre: HastElement;
+  readonly code: HastElement;
+  readonly lines: HastElement[];
+  readonly structure: HighlightOptions["structure"];
+  addClassToHast: (hast: HastElement, className: string | string[]) => HastElement;
 }
 
 export interface ShikiTransformer {
-  name?: string
-  enforce?: 'pre' | 'post'
-  preprocess?: (this: ShikiTransformerContextCommon, code: string, options: HighlightOptions) => string | void
-  tokens?: (this: ShikiTransformerContextCommon & { readonly source: string }, tokens: ThemedToken[][]) => ThemedToken[][] | void
-  root?: (this: ShikiTransformerContext, hast: HastRoot) => HastRoot | void
-  pre?: (this: ShikiTransformerContext, hast: HastElement) => HastElement | void
-  code?: (this: ShikiTransformerContext, hast: HastElement) => HastElement | void
-  line?: (this: ShikiTransformerContext, hast: HastElement, line: number) => HastElement | void
-  span?: (this: ShikiTransformerContext, hast: HastElement, line: number, col: number, lineElement: HastElement, token: ThemedToken) => HastElement | void
-  postprocess?: (this: ShikiTransformerContextCommon, html: string, options: HighlightOptions) => string | void
+  name?: string;
+  enforce?: "pre" | "post";
+  preprocess?: (
+    this: ShikiTransformerContextCommon,
+    code: string,
+    options: HighlightOptions,
+  ) => string | void;
+  tokens?: (
+    this: ShikiTransformerContextCommon & { readonly source: string },
+    tokens: ThemedToken[][],
+  ) => ThemedToken[][] | void;
+  root?: (this: ShikiTransformerContext, hast: HastRoot) => HastRoot | void;
+  pre?: (this: ShikiTransformerContext, hast: HastElement) => HastElement | void;
+  code?: (this: ShikiTransformerContext, hast: HastElement) => HastElement | void;
+  line?: (this: ShikiTransformerContext, hast: HastElement, line: number) => HastElement | void;
+  span?: (
+    this: ShikiTransformerContext,
+    hast: HastElement,
+    line: number,
+    col: number,
+    lineElement: HastElement,
+    token: ThemedToken,
+  ) => HastElement | void;
+  postprocess?: (
+    this: ShikiTransformerContextCommon,
+    html: string,
+    options: HighlightOptions,
+  ) => string | void;
 }
 
 export interface Highlighter {
-  codeToHtml: (code: string, options: HighlightOptions) => string
-  codeToHast: (code: string, options: HighlightOptions) => HastRoot
-  codeToTokens: (code: string, options: HighlightOptions) => TokensResult
-  codeToTokensBase: (code: string, options: HighlightOptions) => ThemedToken[][]
-  codeToTokensWithThemes: (code: string, options: HighlightOptions) => ThemedToken[][]
+  codeToHtml: (code: string, options: HighlightOptions) => string;
+  codeToHast: (code: string, options: HighlightOptions) => HastRoot;
+  codeToTokens: (code: string, options: HighlightOptions) => TokensResult;
+  codeToTokensBase: (code: string, options: HighlightOptions) => ThemedToken[][];
+  codeToTokensWithThemes: (code: string, options: HighlightOptions) => ThemedToken[][];
   getLastGrammarState: {
-    (code: string, options: HighlightOptions): GrammarState
-    (element: ThemedToken[][] | HastRoot): GrammarState | undefined
-  }
-  getLoadedLanguages: () => string[]
-  getLoadedThemes: () => string[]
-  loadLanguage: (...languages: RegistrationInput<LanguageInput>[]) => Promise<void>
-  loadLanguageSync: (...languages: SyncRegistrationInput<LanguageInput>[]) => void
-  loadTheme: (...themes: RegistrationInput<ThemeInput>[]) => Promise<void>
-  loadThemeSync: (...themes: SyncRegistrationInput<ThemeInput>[]) => void
-  resolveLangAlias: (language: string) => string
-  dispose: () => void
-  [Symbol.dispose]: () => void
+    (code: string, options: HighlightOptions): GrammarState;
+    (element: ThemedToken[][] | HastRoot): GrammarState | undefined;
+  };
+  getLoadedLanguages: () => string[];
+  getLoadedThemes: () => string[];
+  loadLanguage: (...languages: RegistrationInput<LanguageInput>[]) => Promise<void>;
+  loadLanguageSync: (...languages: SyncRegistrationInput<LanguageInput>[]) => void;
+  loadTheme: (...themes: RegistrationInput<ThemeInput>[]) => Promise<void>;
+  loadThemeSync: (...themes: SyncRegistrationInput<ThemeInput>[]) => void;
+  resolveLangAlias: (language: string) => string;
+  dispose: () => void;
+  [Symbol.dispose]: () => void;
 }
 
-export type FerrikiErrorCode
-  = | 'ERR_USAGE'
-    | 'ERR_UNSUPPORTED'
-    | 'ERR_NATIVE_LOAD'
-    | 'ERR_ASSET'
-    | 'ERR_RESOURCE_LIMIT'
-    | 'ERR_INTERNAL'
+export type FerrikiErrorCode =
+  | "ERR_USAGE"
+  | "ERR_UNSUPPORTED"
+  | "ERR_NATIVE_LOAD"
+  | "ERR_ASSET"
+  | "ERR_RESOURCE_LIMIT"
+  | "ERR_INTERNAL";
 
 export declare class ShikiError extends Error {
-  readonly code: FerrikiErrorCode
-  constructor(message: string, code?: FerrikiErrorCode, options?: { cause?: unknown })
+  readonly code: FerrikiErrorCode;
+  constructor(message: string, code?: FerrikiErrorCode, options?: { cause?: unknown });
 }
 
 export declare class FerrikiError extends ShikiError {
-  constructor(message: string, code?: FerrikiErrorCode, options?: { cause?: unknown })
+  constructor(message: string, code?: FerrikiErrorCode, options?: { cause?: unknown });
 }
 
 /** Version of the bundled native core, or undefined when no platform binary loads. */
-export declare function ferrikiVersion(): string | undefined
+export declare function ferrikiVersion(): string | undefined;
 
-export declare function createHighlighter(options?: HighlighterOptions): Promise<Highlighter>
-export declare const createHighlighterCore: typeof createHighlighter
-export declare const createShikiPrimitiveAsync: typeof createHighlighter
-export declare function createHighlighterCoreSync(options?: HighlighterSyncOptions): Highlighter
-export declare function createShikiPrimitive(options?: HighlighterSyncOptions): Highlighter
+export declare function createHighlighter(options?: HighlighterOptions): Promise<Highlighter>;
+export declare const createHighlighterCore: typeof createHighlighter;
+export declare const createShikiPrimitiveAsync: typeof createHighlighter;
+export declare function createHighlighterCoreSync(options?: HighlighterSyncOptions): Highlighter;
+export declare function createShikiPrimitive(options?: HighlighterSyncOptions): Highlighter;
 
-export declare function getSingletonHighlighter(options?: HighlighterOptions): Promise<Highlighter>
-export declare const getSingletonHighlighterCore: typeof getSingletonHighlighter
+export declare function getSingletonHighlighter(options?: HighlighterOptions): Promise<Highlighter>;
+export declare const getSingletonHighlighterCore: typeof getSingletonHighlighter;
 
-export declare function codeToHtml(code: string, options: HighlightOptions): Promise<string>
+export declare function codeToHtml(code: string, options: HighlightOptions): Promise<string>;
 export declare function codeToHtml(
   highlighter: Highlighter,
   code: string,
   options: HighlightOptions,
-): string
+): string;
 
-export declare function codeToHast(code: string, options: HighlightOptions): Promise<HastRoot>
+export declare function codeToHast(code: string, options: HighlightOptions): Promise<HastRoot>;
 export declare function codeToHast(
   highlighter: Highlighter,
   code: string,
   options: HighlightOptions,
-): HastRoot
+): HastRoot;
 
-export declare function codeToTokens(code: string, options: HighlightOptions): Promise<TokensResult>
+export declare function codeToTokens(
+  code: string,
+  options: HighlightOptions,
+): Promise<TokensResult>;
 export declare function codeToTokens(
   highlighter: Highlighter,
   code: string,
   options: HighlightOptions,
-): TokensResult
+): TokensResult;
 
 export declare function codeToTokensBase(
   code: string,
   options: HighlightOptions,
-): Promise<ThemedToken[][]>
+): Promise<ThemedToken[][]>;
 export declare function codeToTokensBase(
   highlighter: Highlighter,
   code: string,
   options: HighlightOptions,
-): ThemedToken[][]
+): ThemedToken[][];
 
 export declare function codeToTokensWithThemes(
   code: string,
   options: HighlightOptions,
-): Promise<ThemedToken[][]>
+): Promise<ThemedToken[][]>;
 export declare function codeToTokensWithThemes(
   highlighter: Highlighter,
   code: string,
   options: HighlightOptions,
-): ThemedToken[][]
+): ThemedToken[][];
 
 export declare function getLastGrammarState(
   code: string,
   options: HighlightOptions,
-): Promise<GrammarState>
+): Promise<GrammarState>;
 export declare function getLastGrammarState(
   highlighter: Highlighter,
   code: string,
   options: HighlightOptions,
-): GrammarState
+): GrammarState;
 export declare function getLastGrammarState(
   highlighter: Highlighter,
   element: ThemedToken[][] | HastRoot,
-): GrammarState | undefined
+): GrammarState | undefined;
 
 export interface CssVariablesThemeOptions {
-  name?: string
-  type?: 'dark' | 'light' | string
+  name?: string;
+  type?: "dark" | "light" | string;
   variableDefaults?: {
-    foreground?: string
-    background?: string
-  }
+    foreground?: string;
+    background?: string;
+  };
 }
 
 export declare function createCssVariablesTheme(
   options?: CssVariablesThemeOptions,
-): ThemeRegistration
-export declare function hastToHtml(tree: HastRoot | HastElement): string
+): ThemeRegistration;
+export declare function hastToHtml(tree: HastRoot | HastElement): string;
 
 export declare const bundledLanguages: Readonly<
   Record<string, () => Promise<LanguageRegistration[]>>
->
-export declare const bundledThemes: Readonly<
-  Record<string, () => Promise<ThemeRegistration>>
->
-export declare const bundledLanguagesAlias: Readonly<Record<string, string>>
-export type BundledLanguage = keyof typeof bundledLanguages
-export type BundledTheme = keyof typeof bundledThemes
+>;
+export declare const bundledThemes: Readonly<Record<string, () => Promise<ThemeRegistration>>>;
+export declare const bundledLanguagesAlias: Readonly<Record<string, string>>;
+export type BundledLanguage = keyof typeof bundledLanguages;
+export type BundledTheme = keyof typeof bundledThemes;

--- a/node/ferriki/src/index.mjs
+++ b/node/ferriki/src/index.mjs
@@ -1,120 +1,120 @@
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-import { languageCatalog, themeCatalog } from '../assets/shiki/catalog.mjs'
-import { loadFerrikiNativeBinding, tryLoadFerrikiNativeBinding } from '../native.mjs'
+import { languageCatalog, themeCatalog } from "../assets/shiki/catalog.mjs";
+import { loadFerrikiNativeBinding, tryLoadFerrikiNativeBinding } from "../native.mjs";
 import {
   applyTokenTransformers,
   renderTransformedHast,
   sortTransformers,
   splitTokensAtDecorations,
-} from '../transformers.mjs'
+} from "../transformers.mjs";
 
-const packageDir = dirname(dirname(fileURLToPath(import.meta.url)))
-const standardAssetRoot = join(packageDir, 'assets', 'shiki')
-const NONE_THEME_BACKING = 'nord'
-const grammarStateByObject = new WeakMap()
-let singleton
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const standardAssetRoot = join(packageDir, "assets", "shiki");
+const NONE_THEME_BACKING = "nord";
+const grammarStateByObject = new WeakMap();
+let singleton;
 
 export class ShikiError extends Error {
-  constructor(message, code = 'ERR_USAGE', options) {
-    super(message, options)
-    this.name = 'ShikiError'
-    this.code = code
+  constructor(message, code = "ERR_USAGE", options) {
+    super(message, options);
+    this.name = "ShikiError";
+    this.code = code;
   }
 }
 
 export class FerrikiError extends ShikiError {
-  constructor(message, code = 'ERR_INTERNAL', options) {
-    super(message, code, options)
-    this.name = 'FerrikiError'
+  constructor(message, code = "ERR_INTERNAL", options) {
+    super(message, code, options);
+    this.name = "FerrikiError";
   }
 }
 
 export function ferrikiVersion() {
-  return tryLoadFerrikiNativeBinding()?.ferrikiVersion()
+  return tryLoadFerrikiNativeBinding()?.ferrikiVersion();
 }
 
 export async function createHighlighter(options = {}) {
-  options = validateHighlighterOptions(options)
-  const {
-    langs = [],
-    themes = [],
-    ...coreOptions
-  } = options
-  const highlighter = createHighlighterCoreSync(coreOptions)
-  await Promise.all([
-    highlighter.loadLanguage(...langs),
-    highlighter.loadTheme(...themes),
-  ])
-  return highlighter
+  options = validateHighlighterOptions(options);
+  const { langs = [], themes = [], ...coreOptions } = options;
+  const highlighter = createHighlighterCoreSync(coreOptions);
+  await Promise.all([highlighter.loadLanguage(...langs), highlighter.loadTheme(...themes)]);
+  return highlighter;
 }
 
-export const createHighlighterCore = createHighlighter
-export const createShikiPrimitiveAsync = createHighlighter
+export const createHighlighterCore = createHighlighter;
+export const createShikiPrimitiveAsync = createHighlighter;
 
 export function createHighlighterCoreSync(options = {}) {
-  options = validateHighlighterOptions(options)
-  let native
+  options = validateHighlighterOptions(options);
+  let native;
   try {
-    native = loadFerrikiNativeBinding().createHighlighter(JSON.stringify({
-      standardAssetRoot,
-    }))
-  }
-  catch (cause) {
-    if (cause instanceof FerrikiError)
-      throw cause
-    const detail = cause instanceof Error ? cause.message : String(cause)
-    const missingBinary = detail.includes('No native binary')
+    native = loadFerrikiNativeBinding().createHighlighter(
+      JSON.stringify({
+        standardAssetRoot,
+      }),
+    );
+  } catch (cause) {
+    if (cause instanceof FerrikiError) throw cause;
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    const missingBinary = detail.includes("No native binary");
     throw new FerrikiError(
       missingBinary
         ? `${detail}\nInstall a Ferriki platform binary for this target or choose a documented supported target.`
         : `${detail}\nVerify that the package contains assets/shiki and reinstall it.`,
-      missingBinary ? 'ERR_NATIVE_LOAD' : 'ERR_ASSET',
+      missingBinary ? "ERR_NATIVE_LOAD" : "ERR_ASSET",
       { cause },
-    )
+    );
   }
-  const loadedLanguages = new Set()
-  const loadedThemes = new Set()
-  const languageAliases = { ...(options.langAlias || {}) }
-  let disposed = false
+  const loadedLanguages = new Set();
+  const loadedThemes = new Set();
+  const languageAliases = { ...(options.langAlias || {}) };
+  let disposed = false;
 
   function assertActive() {
-    if (disposed)
-      throw new ShikiError('Shiki instance has been disposed', 'ERR_USAGE')
+    if (disposed) throw new ShikiError("Shiki instance has been disposed", "ERR_USAGE");
   }
 
   function resolveAlias(language) {
-    const visited = new Set()
+    const visited = new Set();
     while (languageAliases[language]) {
       if (visited.has(language))
-        throw new ShikiError(`Circular alias \`${[...visited, language].join(' -> ')}\``, 'ERR_USAGE')
-      visited.add(language)
-      language = languageAliases[language]
+        throw new ShikiError(
+          `Circular alias \`${[...visited, language].join(" -> ")}\``,
+          "ERR_USAGE",
+        );
+      visited.add(language);
+      language = languageAliases[language];
     }
-    return language
+    return language;
   }
 
   function loadLanguageSync(...inputs) {
-    assertActive()
+    assertActive();
     for (const registration of resolveSyncRegistrations(inputs)) {
-      validateLanguageRegistration(registration)
-      const name = registrationName(registration)
-      if (!name)
-        continue
-      const resolved = resolveAlias(name)
-      const custom = isCustomLanguageRegistration(registration)
+      validateLanguageRegistration(registration);
+      const name = registrationName(registration);
+      if (!name) continue;
+      const resolved = resolveAlias(name);
+      const custom = isCustomLanguageRegistration(registration);
       const scope = custom
-        ? callCustomRegistration(() => native.loadCustomGrammar(JSON.stringify(registration)), 'language')
-        : native.loadStandardGrammar(resolved)
+        ? callCustomRegistration(
+            () => native.loadCustomGrammar(JSON.stringify(registration)),
+            "language",
+          )
+        : native.loadStandardGrammar(resolved);
       if (!scope)
-        throw new ShikiError(`Language \`${resolved}\` not found, you may need to load it first`, 'ERR_UNSUPPORTED')
-      loadedLanguages.add(resolved)
+        throw new ShikiError(
+          `Language \`${resolved}\` not found, you may need to load it first`,
+          "ERR_UNSUPPORTED",
+        );
+      loadedLanguages.add(resolved);
       if (custom) {
         for (const alias of registration.aliases || []) {
           if (!isStandardLanguageKey(alias)) {
-            languageAliases[alias] = resolved
-            loadedLanguages.add(alias)
+            languageAliases[alias] = resolved;
+            loadedLanguages.add(alias);
           }
         }
       }
@@ -122,140 +122,148 @@ export function createHighlighterCoreSync(options = {}) {
   }
 
   async function loadLanguage(...inputs) {
-    loadLanguageSync(...await resolveRegistrations(inputs))
+    loadLanguageSync(...(await resolveRegistrations(inputs)));
   }
 
   function loadThemeSync(...inputs) {
-    assertActive()
+    assertActive();
     for (const registration of resolveSyncRegistrations(inputs)) {
-      validateThemeRegistration(registration)
-      const name = registrationName(registration)
-      if (!name)
-        continue
-      if (name !== 'none') {
+      validateThemeRegistration(registration);
+      const name = registrationName(registration);
+      if (!name) continue;
+      if (name !== "none") {
         const loaded = isCustomThemeRegistration(registration)
-          ? callCustomRegistration(() => native.loadCustomTheme(JSON.stringify(registration)), 'theme')
-          : native.loadStandardTheme(name)
+          ? callCustomRegistration(
+              () => native.loadCustomTheme(JSON.stringify(registration)),
+              "theme",
+            )
+          : native.loadStandardTheme(name);
         if (!loaded)
-          throw new ShikiError(`Theme \`${name}\` not found, you may need to load it first`, 'ERR_UNSUPPORTED')
+          throw new ShikiError(
+            `Theme \`${name}\` not found, you may need to load it first`,
+            "ERR_UNSUPPORTED",
+          );
       }
-      loadedThemes.add(name)
+      loadedThemes.add(name);
     }
   }
 
   async function loadTheme(...inputs) {
-    loadThemeSync(...await resolveRegistrations(inputs))
+    loadThemeSync(...(await resolveRegistrations(inputs)));
   }
 
   function prepareOptions(options) {
-    assertActive()
-    const prepared = { ...validateHighlightOptions(options) }
-    if (prepared.lang && typeof prepared.lang !== 'string')
-      loadLanguageSync(prepared.lang)
-    if (prepared.theme && typeof prepared.theme !== 'string')
-      loadThemeSync(prepared.theme)
-    const language = resolveAlias(registrationName(prepared.lang) || 'text')
-    const requestedTheme = registrationName(prepared.theme)
-      || registrationName(selectDefaultTheme(prepared))
-    const theme = requestedTheme === 'none' ? NONE_THEME_BACKING : requestedTheme
+    assertActive();
+    const prepared = { ...validateHighlightOptions(options) };
+    if (prepared.lang && typeof prepared.lang !== "string") loadLanguageSync(prepared.lang);
+    if (prepared.theme && typeof prepared.theme !== "string") loadThemeSync(prepared.theme);
+    const language = resolveAlias(registrationName(prepared.lang) || "text");
+    const requestedTheme =
+      registrationName(prepared.theme) || registrationName(selectDefaultTheme(prepared));
+    const theme = requestedTheme === "none" ? NONE_THEME_BACKING : requestedTheme;
     if (!theme)
-      throw new ShikiError('Invalid options, either `theme` or `themes` must be provided', 'ERR_USAGE')
+      throw new ShikiError(
+        "Invalid options, either `theme` or `themes` must be provided",
+        "ERR_USAGE",
+      );
     if (!isSpecialLanguage(language) && !native.resolveGrammarScope(language))
-      throw new ShikiError(`Language \`${language}\` not found, you may need to load it first`, 'ERR_UNSUPPORTED')
+      throw new ShikiError(
+        `Language \`${language}\` not found, you may need to load it first`,
+        "ERR_UNSUPPORTED",
+      );
     if (!native.loadStandardTheme(theme))
-      throw new ShikiError(`Theme \`${theme}\` not found, you may need to load it first`, 'ERR_UNSUPPORTED')
-    if (!isSpecialLanguage(language))
-      loadedLanguages.add(language)
-    loadedThemes.add(theme)
-    prepared.lang = language
-    prepared.theme = theme
-    delete prepared.themes
+      throw new ShikiError(
+        `Theme \`${theme}\` not found, you may need to load it first`,
+        "ERR_UNSUPPORTED",
+      );
+    if (!isSpecialLanguage(language)) loadedLanguages.add(language);
+    loadedThemes.add(theme);
+    prepared.lang = language;
+    prepared.theme = theme;
+    delete prepared.themes;
     // Transformer callbacks and HAST-only options stay in the JS facade.
-    delete prepared.transformers
-    delete prepared.decorations
-    delete prepared.structure
-    delete prepared.meta
-    delete prepared.data
-    delete prepared.grammarState
-    return prepared
+    delete prepared.transformers;
+    delete prepared.decorations;
+    delete prepared.structure;
+    delete prepared.meta;
+    delete prepared.data;
+    delete prepared.grammarState;
+    return prepared;
   }
 
   function highlightSingleTheme(code, options = {}) {
-    assertAnsiInput(code, options)
-    const result = callNativeOperation(
-      'Ferriki tokenization failed',
-      () => JSON.parse(native.codeToTokens(code, JSON.stringify(prepareOptions(options)))),
-    )
-    if (registrationName(options.theme) === 'none')
-      return normalizeNoneThemeResult(result)
-    return result
+    assertAnsiInput(code, options);
+    const result = callNativeOperation("Ferriki tokenization failed", () =>
+      JSON.parse(native.codeToTokens(code, JSON.stringify(prepareOptions(options)))),
+    );
+    if (registrationName(options.theme) === "none") return normalizeNoneThemeResult(result);
+    return result;
   }
 
   function highlightMultiTheme(code, options) {
-    assertAnsiInput(code, options)
-    const themes = resolveThemeEntries(options)
-    loadThemeSync(...themes.map(theme => theme.input))
+    assertAnsiInput(code, options);
+    const themes = resolveThemeEntries(options);
+    loadThemeSync(...themes.map((theme) => theme.input));
     if (
-      typeof native.codeToTokensWithThemes === 'function'
-      && !themes.some(theme => theme.name === 'none')
+      typeof native.codeToTokensWithThemes === "function" &&
+      !themes.some((theme) => theme.name === "none")
     ) {
-      const prepared = prepareOptions({ ...options, theme: themes[0].name, themes: undefined })
-      prepared.themeEntries = themes
+      const prepared = prepareOptions({ ...options, theme: themes[0].name, themes: undefined });
+      prepared.themeEntries = themes;
       return combineNativeThemeResult(
-        callNativeOperation(
-          'Ferriki multi-theme tokenization failed',
-          () => JSON.parse(native.codeToTokensWithThemes(code, JSON.stringify(prepared))),
+        callNativeOperation("Ferriki multi-theme tokenization failed", () =>
+          JSON.parse(native.codeToTokensWithThemes(code, JSON.stringify(prepared))),
         ),
         options,
-      )
+      );
     }
-    const results = themes.map(theme => ({
+    const results = themes.map((theme) => ({
       ...theme,
-      result: theme.name === 'none'
-        ? normalizeNoneThemeResult(highlightNativeTheme(code, options, NONE_THEME_BACKING))
-        : highlightNativeTheme(code, options, theme.name),
-    }))
-    return combineThemeResults(results, options)
+      result:
+        theme.name === "none"
+          ? normalizeNoneThemeResult(highlightNativeTheme(code, options, NONE_THEME_BACKING))
+          : highlightNativeTheme(code, options, theme.name),
+    }));
+    return combineThemeResults(results, options);
   }
 
   function highlightNativeTheme(code, options, theme) {
-    assertAnsiInput(code, options)
-    const prepared = prepareOptions({ ...options, theme, themes: undefined })
-    return callNativeOperation(
-      'Ferriki tokenization failed',
-      () => JSON.parse(native.codeToTokens(code, JSON.stringify(prepared))),
-    )
+    assertAnsiInput(code, options);
+    const prepared = prepareOptions({ ...options, theme, themes: undefined });
+    return callNativeOperation("Ferriki tokenization failed", () =>
+      JSON.parse(native.codeToTokens(code, JSON.stringify(prepared))),
+    );
   }
 
   function highlightRaw(code, options) {
-    if (hasThemes(options))
-      return highlightMultiTheme(code, options)
-    return registrationName(options?.theme) === 'none'
+    if (hasThemes(options)) return highlightMultiTheme(code, options);
+    return registrationName(options?.theme) === "none"
       ? highlightSingleTheme(code, options)
-      : callNativeOperation(
-          'Ferriki tokenization failed',
-          () => JSON.parse(native.codeToTokens(code, JSON.stringify(prepareOptions(options)))),
-        )
+      : callNativeOperation("Ferriki tokenization failed", () =>
+          JSON.parse(native.codeToTokens(code, JSON.stringify(prepareOptions(options)))),
+        );
   }
 
   function grammarLanguage(options) {
-    const requested = resolveAlias(registrationName(options?.lang) || 'text')
-    return languageCatalog.find(entry => entry.id === requested || entry.aliases.includes(requested))?.id || requested
+    const requested = resolveAlias(registrationName(options?.lang) || "text");
+    return (
+      languageCatalog.find((entry) => entry.id === requested || entry.aliases.includes(requested))
+        ?.id || requested
+    );
   }
 
   function grammarThemes(options, result) {
-    if (hasThemes(options))
-      return resolveThemeEntries(options).map(theme => theme.name)
-    return [registrationName(options?.theme) || result.themeName]
+    if (hasThemes(options)) return resolveThemeEntries(options).map((theme) => theme.name);
+    return [registrationName(options?.theme) || result.themeName];
   }
 
   function makeGrammarState(code, options, result) {
-    const language = grammarLanguage(options)
-    const themes = grammarThemes(options, result)
-    const lastToken = result.tokens.flat().at(-1)
+    const language = grammarLanguage(options);
+    const themes = grammarThemes(options, result);
+    const lastToken = result.tokens.flat().at(-1);
     const scopes = lastToken?.scopeNames?.length
       ? [...lastToken.scopeNames.slice(0, -1)].reverse()
-      : [scopeNameForLanguage(language)]
+      : [scopeNameForLanguage(language)];
     return {
       version: 1,
       lang: language,
@@ -265,107 +273,125 @@ export function createHighlighterCoreSync(options = {}) {
       // Ferriki keeps the context in the serializable state so a state can
       // cross a worker or process boundary without leaking native pointers.
       source: code,
-    }
+    };
   }
 
   function validateGrammarState(state, options) {
-    if (!state || typeof state !== 'object' || Array.isArray(state)
-      || state.version !== 1
-      || typeof state.lang !== 'string'
-      || !Array.isArray(state.themes)
-      || state.themes.some(theme => typeof theme !== 'string')
-      || typeof state.source !== 'string') {
-      throw new ShikiError('Invalid grammar state', 'ERR_USAGE')
+    if (
+      !state ||
+      typeof state !== "object" ||
+      Array.isArray(state) ||
+      state.version !== 1 ||
+      typeof state.lang !== "string" ||
+      !Array.isArray(state.themes) ||
+      state.themes.some((theme) => typeof theme !== "string") ||
+      typeof state.source !== "string"
+    ) {
+      throw new ShikiError("Invalid grammar state", "ERR_USAGE");
     }
-    const language = grammarLanguage(options)
+    const language = grammarLanguage(options);
     if (state.lang !== language)
-      throw new ShikiError(`Grammar state language "${state.lang}" does not match highlight language "${language}"`, 'ERR_USAGE')
-    const requestedThemes = grammarThemes(options, { themeName: registrationName(options?.theme) })
+      throw new ShikiError(
+        `Grammar state language "${state.lang}" does not match highlight language "${language}"`,
+        "ERR_USAGE",
+      );
+    const requestedThemes = grammarThemes(options, { themeName: registrationName(options?.theme) });
     for (const theme of requestedThemes) {
       if (!state.themes.includes(theme))
-        throw new ShikiError(`Grammar state themes "${state.themes.join(',')}" do not contain highlight theme "${theme}"`, 'ERR_USAGE')
+        throw new ShikiError(
+          `Grammar state themes "${state.themes.join(",")}" do not contain highlight theme "${theme}"`,
+          "ERR_USAGE",
+        );
     }
-    return state
+    return state;
   }
 
   function prepareGrammarInput(code, options) {
-    const state = options?.grammarState
-    if (!state)
-      return { source: code, prefixLength: 0, prefixLines: 0 }
-    validateGrammarState(state, options)
-    const separator = state.source.endsWith('\n') ? '' : '\n'
+    const state = options?.grammarState;
+    if (!state) return { source: code, prefixLength: 0, prefixLines: 0 };
+    validateGrammarState(state, options);
+    const separator = state.source.endsWith("\n") ? "" : "\n";
     return {
       source: `${state.source}${separator}${code}`,
       prefixLength: state.source.length + separator.length,
-      prefixLines: state.source.split('\n').length - (separator ? 0 : 1),
-    }
+      prefixLines: state.source.split("\n").length - (separator ? 0 : 1),
+    };
   }
 
   function removeGrammarPrefix(result, prefixLength, prefixLines) {
-    if (!prefixLength)
-      return result
+    if (!prefixLength) return result;
     return {
       ...result,
-      tokens: result.tokens.slice(prefixLines).map(line => line.map(token => ({
-        ...token,
-        offset: token.offset - prefixLength,
-      }))),
-    }
+      tokens: result.tokens.slice(prefixLines).map((line) =>
+        line.map((token) => ({
+          ...token,
+          offset: token.offset - prefixLength,
+        })),
+      ),
+    };
   }
 
   function addTokenMetadata(result, options) {
-    const language = grammarLanguage(options)
-    const includeScopes = options?.includeExplanation === true || options?.includeExplanation === 'scopeName'
-    const tokens = result.tokens.map(line => line.map((token) => {
-      const scopeNames = token.scopeNames?.length ? token.scopeNames : [scopeNameForLanguage(language)]
-      const output = { ...token }
-      delete output.scopeNames
-      if (includeScopes) {
-        output.explanation = [{
-          content: token.content,
-          scopes: scopeNames.map(scopeName => ({ scopeName })),
-        }]
-      }
-      return output
-    }))
-    return { ...result, tokens }
+    const language = grammarLanguage(options);
+    const includeScopes =
+      options?.includeExplanation === true || options?.includeExplanation === "scopeName";
+    const tokens = result.tokens.map((line) =>
+      line.map((token) => {
+        const scopeNames = token.scopeNames?.length
+          ? token.scopeNames
+          : [scopeNameForLanguage(language)];
+        const output = { ...token };
+        delete output.scopeNames;
+        if (includeScopes) {
+          output.explanation = [
+            {
+              content: token.content,
+              scopes: scopeNames.map((scopeName) => ({ scopeName })),
+            },
+          ];
+        }
+        return output;
+      }),
+    );
+    return { ...result, tokens };
   }
 
   function highlightTokensPublic(code, options = {}) {
-    const validated = validateHighlightOptions(options)
-    const input = prepareGrammarInput(code, validated)
+    const validated = validateHighlightOptions(options);
+    const input = prepareGrammarInput(code, validated);
     const sourceOptions = input.prefixLength
       ? { ...validated, grammarState: undefined }
-      : { ...validated }
+      : { ...validated };
     // Capture scope paths for the serializable grammar state even when the
     // caller did not request explanation metadata in the returned tokens.
     if (sourceOptions.includeExplanation === undefined)
-      sourceOptions.includeExplanation = 'scopeName'
-    let result
-    if (sourceOptions?.transformers?.some(transformer => transformer?.preprocess || transformer?.tokens))
-      result = highlightWithTransformers(input.source, sourceOptions)
-    else if (hasThemes(sourceOptions))
-      result = highlightMultiTheme(input.source, sourceOptions)
-    else if (registrationName(sourceOptions?.theme) === 'none')
-      result = highlightSingleTheme(input.source, sourceOptions)
-    else
-      result = highlightSingleTheme(input.source, sourceOptions)
-    result = removeGrammarPrefix(result, input.prefixLength, input.prefixLines)
-    const grammarState = makeGrammarState(input.source, validated, result)
-    result = addTokenMetadata(result, validated)
-    result.grammarState = grammarState
-    grammarStateByObject.set(result.tokens, grammarState)
-    return result
+      sourceOptions.includeExplanation = "scopeName";
+    let result;
+    if (
+      sourceOptions?.transformers?.some(
+        (transformer) => transformer?.preprocess || transformer?.tokens,
+      )
+    )
+      result = highlightWithTransformers(input.source, sourceOptions);
+    else if (hasThemes(sourceOptions)) result = highlightMultiTheme(input.source, sourceOptions);
+    else if (registrationName(sourceOptions?.theme) === "none")
+      result = highlightSingleTheme(input.source, sourceOptions);
+    else result = highlightSingleTheme(input.source, sourceOptions);
+    result = removeGrammarPrefix(result, input.prefixLength, input.prefixLines);
+    const grammarState = makeGrammarState(input.source, validated, result);
+    result = addTokenMetadata(result, validated);
+    result.grammarState = grammarState;
+    grammarStateByObject.set(result.tokens, grammarState);
+    return result;
   }
 
   function getGrammarState(codeOrElement, options) {
-    if (typeof codeOrElement !== 'string')
-      return grammarStateByObject.get(codeOrElement)
-    const validated = validateHighlightOptions(options)
-    const language = grammarLanguage(validated)
-    if (isSpecialLanguage(language) || language === 'ansi')
-      throw new ShikiError('Plain language does not have grammar state', 'ERR_USAGE')
-    return highlightTokensPublic(codeOrElement, validated).grammarState
+    if (typeof codeOrElement !== "string") return grammarStateByObject.get(codeOrElement);
+    const validated = validateHighlightOptions(options);
+    const language = grammarLanguage(validated);
+    if (isSpecialLanguage(language) || language === "ansi")
+      throw new ShikiError("Plain language does not have grammar state", "ERR_USAGE");
+    return highlightTokensPublic(codeOrElement, validated).grammarState;
   }
 
   function createTransformerContext(source, options, meta) {
@@ -374,111 +400,109 @@ export function createHighlighterCoreSync(options = {}) {
       options,
       source,
       codeToHast: (nestedCode, nestedOptions) => buildHast(nestedCode, nestedOptions),
-      codeToTokens: (nestedCode, nestedOptions) => highlightWithTransformers(nestedCode, nestedOptions),
-    }
+      codeToTokens: (nestedCode, nestedOptions) =>
+        highlightWithTransformers(nestedCode, nestedOptions),
+    };
   }
 
   function getTransformers(options) {
-    return sortTransformers(options?.transformers)
+    return sortTransformers(options?.transformers);
   }
 
   function highlightWithTransformers(code, options = {}) {
-    const validated = validateHighlightOptions(options)
-    const transformers = getTransformers(validated)
-    const meta = {}
-    const context = createTransformerContext(code, validated, meta)
-    let source = code
+    const validated = validateHighlightOptions(options);
+    const transformers = getTransformers(validated);
+    const meta = {};
+    const context = createTransformerContext(code, validated, meta);
+    let source = code;
     for (const transformer of transformers)
-      source = transformer?.preprocess?.call(context, source, validated) || source
-    context.source = source
-    const result = highlightRaw(source, validated)
-    result.tokens = applyTokenTransformers(result.tokens, transformers, context)
-    return result
+      source = transformer?.preprocess?.call(context, source, validated) || source;
+    context.source = source;
+    const result = highlightRaw(source, validated);
+    result.tokens = applyTokenTransformers(result.tokens, transformers, context);
+    return result;
   }
 
   function buildHast(code, options = {}) {
-    const validated = validateHighlightOptions(options)
-    const transformers = getTransformers(validated)
-    const meta = {}
-    const context = createTransformerContext(code, validated, meta)
-    let source = code
+    const validated = validateHighlightOptions(options);
+    const transformers = getTransformers(validated);
+    const meta = {};
+    const context = createTransformerContext(code, validated, meta);
+    let source = code;
     for (const transformer of transformers)
-      source = transformer?.preprocess?.call(context, source, validated) || source
-    context.source = source
-    const result = highlightRaw(source, validated)
-    result.tokens = applyTokenTransformers(result.tokens, transformers, context)
+      source = transformer?.preprocess?.call(context, source, validated) || source;
+    context.source = source;
+    const result = highlightRaw(source, validated);
+    result.tokens = applyTokenTransformers(result.tokens, transformers, context);
     if (validated.decorations?.length)
-      result.tokens = splitTokensAtDecorations(result.tokens, validated.decorations, source)
-    return renderTransformedHast(result, validated, transformers, context, source)
+      result.tokens = splitTokensAtDecorations(result.tokens, validated.decorations, source);
+    return renderTransformedHast(result, validated, transformers, context, source);
   }
 
   const highlighter = {
     codeToHtml(code, options) {
-      assertAnsiInput(code, options)
+      assertAnsiInput(code, options);
       if (options?.grammarState) {
-        const result = highlightTokensPublic(code, options)
-        return applyPostprocess(hastToHtml(renderTokenResultHast(result, options)), options, code)
+        const result = highlightTokensPublic(code, options);
+        return applyPostprocess(hastToHtml(renderTokenResultHast(result, options)), options, code);
       }
       if (hasHastPipeline(options)) {
-        const validated = validateHighlightOptions(options)
-        const html = hastToHtml(buildHast(code, validated))
-        return applyPostprocess(html, validated, code)
+        const validated = validateHighlightOptions(options);
+        const html = hastToHtml(buildHast(code, validated));
+        return applyPostprocess(html, validated, code);
       }
       if (hasThemes(options))
-        return hastToHtml(renderTokenResultHast(highlightMultiTheme(code, options), options))
-      if (registrationName(options?.theme) === 'none')
-        return hastToHtml(renderTokenResultHast(highlightSingleTheme(code, options), options))
-      return callNativeOperation(
-        'Ferriki HTML rendering failed',
-        () => native.codeToHtml(code, JSON.stringify(prepareOptions(options))),
-      )
+        return hastToHtml(renderTokenResultHast(highlightMultiTheme(code, options), options));
+      if (registrationName(options?.theme) === "none")
+        return hastToHtml(renderTokenResultHast(highlightSingleTheme(code, options), options));
+      return callNativeOperation("Ferriki HTML rendering failed", () =>
+        native.codeToHtml(code, JSON.stringify(prepareOptions(options))),
+      );
     },
     codeToHast(code, options) {
-      assertAnsiInput(code, options)
+      assertAnsiInput(code, options);
       if (options?.grammarState) {
-        const result = highlightTokensPublic(code, options)
-        const tree = renderTokenResultHast(result, options)
-        grammarStateByObject.set(tree, result.grammarState)
-        return tree
+        const result = highlightTokensPublic(code, options);
+        const tree = renderTokenResultHast(result, options);
+        grammarStateByObject.set(tree, result.grammarState);
+        return tree;
       }
-      if (hasHastPipeline(options))
-        return buildHast(code, options)
-      if (hasThemes(options) || registrationName(options?.theme) === 'none') {
+      if (hasHastPipeline(options)) return buildHast(code, options);
+      if (hasThemes(options) || registrationName(options?.theme) === "none") {
         const result = hasThemes(options)
           ? highlightMultiTheme(code, options)
-          : highlightSingleTheme(code, options)
-        const tree = renderTokenResultHast(result, options)
+          : highlightSingleTheme(code, options);
+        const tree = renderTokenResultHast(result, options);
         if (!isSpecialLanguage(grammarLanguage(options)))
-          grammarStateByObject.set(tree, getGrammarState(code, options))
-        return tree
+          grammarStateByObject.set(tree, getGrammarState(code, options));
+        return tree;
       }
-      const tree = callNativeOperation(
-        'Ferriki HAST rendering failed',
-        () => JSON.parse(native.codeToHast(code, JSON.stringify(prepareOptions(options)))),
-      )
+      const tree = callNativeOperation("Ferriki HAST rendering failed", () =>
+        JSON.parse(native.codeToHast(code, JSON.stringify(prepareOptions(options)))),
+      );
       if (!isSpecialLanguage(grammarLanguage(options)))
-        grammarStateByObject.set(tree, getGrammarState(code, options))
-      return tree
+        grammarStateByObject.set(tree, getGrammarState(code, options));
+      return tree;
     },
     codeToTokens(code, options) {
-      assertAnsiInput(code, options)
-      return highlightTokensPublic(code, options)
+      assertAnsiInput(code, options);
+      return highlightTokensPublic(code, options);
     },
     codeToTokensBase(code, options) {
-      return this.codeToTokens(code, options).tokens
+      return this.codeToTokens(code, options).tokens;
     },
     codeToTokensWithThemes(code, options) {
-      return highlightTokensPublic(code, options).tokens
+      return highlightTokensPublic(code, options).tokens;
     },
     getLoadedLanguages() {
-      const nativeLanguages = native.getLoadedLanguages()
+      const nativeLanguages = native.getLoadedLanguages();
       const configuredAliases = Object.entries(languageAliases)
         .filter(([, target]) => nativeLanguages.includes(resolveAlias(target)))
-        .map(([alias]) => alias)
-      return [...new Set([...nativeLanguages, ...configuredAliases])]
+        .map(([alias]) => alias);
+      return [...new Set([...nativeLanguages, ...configuredAliases])];
     },
     getLoadedThemes() {
-      return [...loadedThemes]
+      return [...loadedThemes];
     },
     loadLanguage,
     loadLanguageSync,
@@ -488,739 +512,850 @@ export function createHighlighterCoreSync(options = {}) {
     getLastGrammarState: getGrammarState,
     dispose() {
       if (!disposed) {
-        disposed = true
-        native.dispose()
+        disposed = true;
+        native.dispose();
       }
     },
     [Symbol.dispose]() {
-      this.dispose()
+      this.dispose();
     },
-  }
+  };
 
-  loadLanguageSync(...(options.langs || []))
-  loadThemeSync(...(options.themes || []))
-  return highlighter
+  loadLanguageSync(...(options.langs || []));
+  loadThemeSync(...(options.themes || []));
+  return highlighter;
 }
 
 export function createShikiPrimitive(options = {}) {
-  return createHighlighterCoreSync(options)
+  return createHighlighterCoreSync(options);
 }
 
 export async function getSingletonHighlighter(options = {}) {
-  singleton ||= createHighlighter(options)
-  const highlighter = await singleton
-  if (options.langs?.length)
-    await highlighter.loadLanguage(...options.langs)
-  if (options.themes?.length)
-    await highlighter.loadTheme(...options.themes)
-  return highlighter
+  singleton ||= createHighlighter(options);
+  const highlighter = await singleton;
+  if (options.langs?.length) await highlighter.loadLanguage(...options.langs);
+  if (options.themes?.length) await highlighter.loadTheme(...options.themes);
+  return highlighter;
 }
 
-export const getSingletonHighlighterCore = getSingletonHighlighter
+export const getSingletonHighlighterCore = getSingletonHighlighter;
 
 export function codeToHtml(highlighterOrCode, codeOrOptions, options) {
-  if (isHighlighter(highlighterOrCode, 'codeToHtml'))
-    return highlighterOrCode.codeToHtml(codeOrOptions, options)
-  return getSingletonHighlighter()
-    .then(highlighter => highlighter.codeToHtml(highlighterOrCode, codeOrOptions))
+  if (isHighlighter(highlighterOrCode, "codeToHtml"))
+    return highlighterOrCode.codeToHtml(codeOrOptions, options);
+  return getSingletonHighlighter().then((highlighter) =>
+    highlighter.codeToHtml(highlighterOrCode, codeOrOptions),
+  );
 }
 
 export function codeToHast(highlighterOrCode, codeOrOptions, options) {
-  if (isHighlighter(highlighterOrCode, 'codeToHast'))
-    return highlighterOrCode.codeToHast(codeOrOptions, options)
-  return getSingletonHighlighter()
-    .then(highlighter => highlighter.codeToHast(highlighterOrCode, codeOrOptions))
+  if (isHighlighter(highlighterOrCode, "codeToHast"))
+    return highlighterOrCode.codeToHast(codeOrOptions, options);
+  return getSingletonHighlighter().then((highlighter) =>
+    highlighter.codeToHast(highlighterOrCode, codeOrOptions),
+  );
 }
 
 export function codeToTokens(highlighterOrCode, codeOrOptions, options) {
-  if (isHighlighter(highlighterOrCode, 'codeToTokens'))
-    return highlighterOrCode.codeToTokens(codeOrOptions, options)
-  return getSingletonHighlighter()
-    .then(highlighter => highlighter.codeToTokens(highlighterOrCode, codeOrOptions))
+  if (isHighlighter(highlighterOrCode, "codeToTokens"))
+    return highlighterOrCode.codeToTokens(codeOrOptions, options);
+  return getSingletonHighlighter().then((highlighter) =>
+    highlighter.codeToTokens(highlighterOrCode, codeOrOptions),
+  );
 }
 
 export function codeToTokensBase(highlighterOrCode, codeOrOptions, options) {
-  if (isHighlighter(highlighterOrCode, 'codeToTokensBase'))
-    return highlighterOrCode.codeToTokensBase(codeOrOptions, options)
-  return codeToTokens(highlighterOrCode, codeOrOptions)
-    .then(result => result.tokens)
+  if (isHighlighter(highlighterOrCode, "codeToTokensBase"))
+    return highlighterOrCode.codeToTokensBase(codeOrOptions, options);
+  return codeToTokens(highlighterOrCode, codeOrOptions).then((result) => result.tokens);
 }
 
 export function codeToTokensWithThemes(highlighterOrCode, codeOrOptions, options) {
-  if (isHighlighter(highlighterOrCode, 'codeToTokensWithThemes'))
-    return highlighterOrCode.codeToTokensWithThemes(codeOrOptions, options)
-  return codeToTokens(highlighterOrCode, codeOrOptions)
-    .then(result => result.tokens)
+  if (isHighlighter(highlighterOrCode, "codeToTokensWithThemes"))
+    return highlighterOrCode.codeToTokensWithThemes(codeOrOptions, options);
+  return codeToTokens(highlighterOrCode, codeOrOptions).then((result) => result.tokens);
 }
 
 export function getLastGrammarState(highlighterOrCode, codeOrOptions, options) {
-  if (isHighlighter(highlighterOrCode, 'getLastGrammarState'))
-    return highlighterOrCode.getLastGrammarState(codeOrOptions, options)
-  if (typeof highlighterOrCode === 'string') {
-    return getSingletonHighlighter()
-      .then(highlighter => highlighter.getLastGrammarState(highlighterOrCode, codeOrOptions))
+  if (isHighlighter(highlighterOrCode, "getLastGrammarState"))
+    return highlighterOrCode.getLastGrammarState(codeOrOptions, options);
+  if (typeof highlighterOrCode === "string") {
+    return getSingletonHighlighter().then((highlighter) =>
+      highlighter.getLastGrammarState(highlighterOrCode, codeOrOptions),
+    );
   }
-  return undefined
+  return undefined;
 }
 
 export function createCssVariablesTheme(options = {}) {
   return {
-    name: options.name || 'css-variables',
-    type: options.type || 'dark',
-    fg: options.variableDefaults?.foreground || 'var(--shiki-foreground)',
-    bg: options.variableDefaults?.background || 'var(--shiki-background)',
+    name: options.name || "css-variables",
+    type: options.type || "dark",
+    fg: options.variableDefaults?.foreground || "var(--shiki-foreground)",
+    bg: options.variableDefaults?.background || "var(--shiki-background)",
     settings: [],
-  }
+  };
 }
 
 export function hastToHtml(tree) {
-  return (tree.children || []).map(nodeToHtml).join('')
+  return (tree.children || []).map(nodeToHtml).join("");
 }
 
-export const bundledLanguages = createLanguageBundle(languageCatalog)
-export const bundledThemes = createThemeBundle(themeCatalog)
-export const bundledLanguagesAlias = createLanguageAliasBundle(languageCatalog)
+export const bundledLanguages = createLanguageBundle(languageCatalog);
+export const bundledThemes = createThemeBundle(themeCatalog);
+export const bundledLanguagesAlias = createLanguageAliasBundle(languageCatalog);
 
-const standardLanguageKeys = new Set(languageCatalog.flatMap(entry => [entry.id, ...entry.aliases]))
-const standardThemeKeys = new Set(themeCatalog.map(entry => entry.id))
+const standardLanguageKeys = new Set(
+  languageCatalog.flatMap((entry) => [entry.id, ...entry.aliases]),
+);
+const standardThemeKeys = new Set(themeCatalog.map((entry) => entry.id));
 
 function createLanguageBundle(catalog) {
-  const loaders = new Map()
+  const loaders = new Map();
   for (const entry of catalog) {
-    const loader = createLanguageLoader(entry)
-    loaders.set(entry.id, loader)
-    for (const alias of entry.aliases)
-      loaders.set(alias, loader)
+    const loader = createLanguageLoader(entry);
+    loaders.set(entry.id, loader);
+    for (const alias of entry.aliases) loaders.set(alias, loader);
   }
-  return Object.freeze(Object.fromEntries([...loaders].sort(([left], [right]) => compareIds(left, right))))
+  return Object.freeze(
+    Object.fromEntries([...loaders].sort(([left], [right]) => compareIds(left, right))),
+  );
 }
 
 function createLanguageAliasBundle(catalog) {
-  const aliases = new Map()
+  const aliases = new Map();
   for (const entry of catalog) {
-    for (const alias of entry.aliases)
-      aliases.set(alias, entry.id)
+    for (const alias of entry.aliases) aliases.set(alias, entry.id);
   }
-  return Object.freeze(Object.fromEntries([...aliases].sort(([left], [right]) => compareIds(left, right))))
+  return Object.freeze(
+    Object.fromEntries([...aliases].sort(([left], [right]) => compareIds(left, right))),
+  );
 }
 
 function createLanguageLoader(entry) {
-  return async () => [{
-    name: entry.id,
-    scopeName: entry.scopeName,
-    displayName: entry.displayName || undefined,
-    aliases: [...entry.aliases],
-    embeddedLangs: [...entry.embeddedLangs],
-    embeddedLangsLazy: [...entry.embeddedLangsLazy],
-    injectTo: [...entry.injectTo],
-  }]
+  return async () => [
+    {
+      name: entry.id,
+      scopeName: entry.scopeName,
+      displayName: entry.displayName || undefined,
+      aliases: [...entry.aliases],
+      embeddedLangs: [...entry.embeddedLangs],
+      embeddedLangsLazy: [...entry.embeddedLangsLazy],
+      injectTo: [...entry.injectTo],
+    },
+  ];
 }
 
 function createThemeBundle(catalog) {
-  const loaders = Object.fromEntries(catalog.map(entry => [
-    entry.id,
-    async () => ({
-      name: entry.id,
-      type: entry.themeType || undefined,
-    }),
-  ]))
-  return Object.freeze(loaders)
+  const loaders = Object.fromEntries(
+    catalog.map((entry) => [
+      entry.id,
+      async () => ({
+        name: entry.id,
+        type: entry.themeType || undefined,
+      }),
+    ]),
+  );
+  return Object.freeze(loaders);
 }
 
 function validateHighlightOptions(options) {
-  if (options == null)
-    return {}
-  if (typeof options !== 'object' || Array.isArray(options))
-    throw new ShikiError('Highlight options must be an object', 'ERR_USAGE')
+  if (options == null) return {};
+  if (typeof options !== "object" || Array.isArray(options))
+    throw new ShikiError("Highlight options must be an object", "ERR_USAGE");
 
-  const registrationFields = ['lang', 'theme']
+  const registrationFields = ["lang", "theme"];
   for (const field of registrationFields) {
-    const value = options[field]
-    if (value !== undefined && (typeof value !== 'string' && (!value || typeof value !== 'object' || Array.isArray(value))))
-      throw new ShikiError(`Highlight option \`${field}\` must be a name or registration object`, 'ERR_USAGE')
+    const value = options[field];
+    if (
+      value !== undefined &&
+      typeof value !== "string" &&
+      (!value || typeof value !== "object" || Array.isArray(value))
+    )
+      throw new ShikiError(
+        `Highlight option \`${field}\` must be a name or registration object`,
+        "ERR_USAGE",
+      );
   }
-  if (options.themes !== undefined && (!options.themes || typeof options.themes !== 'object' || Array.isArray(options.themes)))
-    throw new ShikiError('Highlight option `themes` must be an object', 'ERR_USAGE')
-  if (options.defaultColor !== undefined && options.defaultColor !== false && typeof options.defaultColor !== 'string')
-    throw new ShikiError('Highlight option `defaultColor` must be a string or false', 'ERR_USAGE')
-  if (options.cssVariablePrefix !== undefined && typeof options.cssVariablePrefix !== 'string')
-    throw new ShikiError('Highlight option `cssVariablePrefix` must be a string', 'ERR_USAGE')
-  if (options.includeExplanation !== undefined
-    && typeof options.includeExplanation !== 'boolean'
-    && !['scopeName', 'tokenType'].includes(options.includeExplanation)) {
-    throw new ShikiError('Highlight option `includeExplanation` has an unsupported value', 'ERR_USAGE')
+  if (
+    options.themes !== undefined &&
+    (!options.themes || typeof options.themes !== "object" || Array.isArray(options.themes))
+  )
+    throw new ShikiError("Highlight option `themes` must be an object", "ERR_USAGE");
+  if (
+    options.defaultColor !== undefined &&
+    options.defaultColor !== false &&
+    typeof options.defaultColor !== "string"
+  )
+    throw new ShikiError("Highlight option `defaultColor` must be a string or false", "ERR_USAGE");
+  if (options.cssVariablePrefix !== undefined && typeof options.cssVariablePrefix !== "string")
+    throw new ShikiError("Highlight option `cssVariablePrefix` must be a string", "ERR_USAGE");
+  if (
+    options.includeExplanation !== undefined &&
+    typeof options.includeExplanation !== "boolean" &&
+    !["scopeName", "tokenType"].includes(options.includeExplanation)
+  ) {
+    throw new ShikiError(
+      "Highlight option `includeExplanation` has an unsupported value",
+      "ERR_USAGE",
+    );
   }
-  if (options.grammarState !== undefined
-    && (!options.grammarState || typeof options.grammarState !== 'object' || Array.isArray(options.grammarState))) {
-    throw new ShikiError('Highlight option `grammarState` must be an object', 'ERR_USAGE')
+  if (
+    options.grammarState !== undefined &&
+    (!options.grammarState ||
+      typeof options.grammarState !== "object" ||
+      Array.isArray(options.grammarState))
+  ) {
+    throw new ShikiError("Highlight option `grammarState` must be an object", "ERR_USAGE");
   }
-  for (const field of ['mergeWhitespaces', 'mergeSameStyleTokens']) {
-    if (options[field] !== undefined && typeof options[field] !== 'boolean')
-      throw new ShikiError(`Highlight option \`${field}\` must be boolean`, 'ERR_USAGE')
+  for (const field of ["mergeWhitespaces", "mergeSameStyleTokens"]) {
+    if (options[field] !== undefined && typeof options[field] !== "boolean")
+      throw new ShikiError(`Highlight option \`${field}\` must be boolean`, "ERR_USAGE");
   }
-  if (options.rootStyle !== undefined && options.rootStyle !== false && typeof options.rootStyle !== 'string')
-    throw new ShikiError('Highlight option `rootStyle` must be a string or false', 'ERR_USAGE')
-  if (options.tabindex !== undefined
-    && options.tabindex !== null
-    && options.tabindex !== false
-    && typeof options.tabindex !== 'string'
-    && (typeof options.tabindex !== 'number' || !Number.isFinite(options.tabindex))) {
-    throw new ShikiError('Highlight option `tabindex` must be a string, number, false, or null', 'ERR_USAGE')
+  if (
+    options.rootStyle !== undefined &&
+    options.rootStyle !== false &&
+    typeof options.rootStyle !== "string"
+  )
+    throw new ShikiError("Highlight option `rootStyle` must be a string or false", "ERR_USAGE");
+  if (
+    options.tabindex !== undefined &&
+    options.tabindex !== null &&
+    options.tabindex !== false &&
+    typeof options.tabindex !== "string" &&
+    (typeof options.tabindex !== "number" || !Number.isFinite(options.tabindex))
+  ) {
+    throw new ShikiError(
+      "Highlight option `tabindex` must be a string, number, false, or null",
+      "ERR_USAGE",
+    );
   }
-  for (const field of ['tokenizeMaxLineLength', 'tokenizeTimeLimit']) {
-    if (options[field] !== undefined
-      && (typeof options[field] !== 'number' || !Number.isFinite(options[field]) || options[field] < 0)) {
-      throw new ShikiError(`Highlight option \`${field}\` must be a non-negative number`, 'ERR_USAGE')
+  for (const field of ["tokenizeMaxLineLength", "tokenizeTimeLimit"]) {
+    if (
+      options[field] !== undefined &&
+      (typeof options[field] !== "number" || !Number.isFinite(options[field]) || options[field] < 0)
+    ) {
+      throw new ShikiError(
+        `Highlight option \`${field}\` must be a non-negative number`,
+        "ERR_USAGE",
+      );
     }
   }
   if (options.transformers !== undefined && !Array.isArray(options.transformers))
-    throw new ShikiError('Highlight option transformers must be an array', 'ERR_USAGE')
+    throw new ShikiError("Highlight option transformers must be an array", "ERR_USAGE");
   if (options.decorations !== undefined && !Array.isArray(options.decorations))
-    throw new ShikiError('Highlight option decorations must be an array', 'ERR_USAGE')
-  if (options.structure !== undefined && options.structure !== 'classic' && options.structure !== 'inline')
-    throw new ShikiError('Highlight option structure must be classic or inline', 'ERR_USAGE')
-  for (const field of ['engine', 'loadWasm', 'wasmBinary']) {
+    throw new ShikiError("Highlight option decorations must be an array", "ERR_USAGE");
+  if (
+    options.structure !== undefined &&
+    options.structure !== "classic" &&
+    options.structure !== "inline"
+  )
+    throw new ShikiError("Highlight option structure must be classic or inline", "ERR_USAGE");
+  for (const field of ["engine", "loadWasm", "wasmBinary"]) {
     if (options[field] !== undefined)
-      throw new ShikiError(`Highlight option \`${field}\` is not supported by Ferriki`, 'ERR_UNSUPPORTED')
+      throw new ShikiError(
+        `Highlight option \`${field}\` is not supported by Ferriki`,
+        "ERR_UNSUPPORTED",
+      );
   }
-  return options
+  return options;
 }
 
 function validateHighlighterOptions(options) {
-  if (options == null)
-    return {}
-  if (typeof options !== 'object' || Array.isArray(options))
-    throw new ShikiError('Highlighter options must be an object', 'ERR_USAGE')
-  for (const field of ['langs', 'themes']) {
+  if (options == null) return {};
+  if (typeof options !== "object" || Array.isArray(options))
+    throw new ShikiError("Highlighter options must be an object", "ERR_USAGE");
+  for (const field of ["langs", "themes"]) {
     if (options[field] !== undefined && !Array.isArray(options[field]))
-      throw new ShikiError(`Highlighter option \`${field}\` must be an array`, 'ERR_USAGE')
+      throw new ShikiError(`Highlighter option \`${field}\` must be an array`, "ERR_USAGE");
   }
-  if (options.langAlias !== undefined
-    && (!options.langAlias || typeof options.langAlias !== 'object' || Array.isArray(options.langAlias))) {
-    throw new ShikiError('Highlighter option `langAlias` must be an object', 'ERR_USAGE')
+  if (
+    options.langAlias !== undefined &&
+    (!options.langAlias ||
+      typeof options.langAlias !== "object" ||
+      Array.isArray(options.langAlias))
+  ) {
+    throw new ShikiError("Highlighter option `langAlias` must be an object", "ERR_USAGE");
   }
   if (options.langAlias) {
     for (const [alias, target] of Object.entries(options.langAlias)) {
-      if (!alias || typeof target !== 'string' || !target)
-        throw new ShikiError('Highlighter option `langAlias` must map non-empty names to strings', 'ERR_USAGE')
+      if (!alias || typeof target !== "string" || !target)
+        throw new ShikiError(
+          "Highlighter option `langAlias` must map non-empty names to strings",
+          "ERR_USAGE",
+        );
     }
   }
-  return options
+  return options;
 }
 
 function validateLanguageRegistration(registration) {
-  if (typeof registration === 'string')
-    return
-  if (!registration || typeof registration !== 'object' || Array.isArray(registration))
-    throw new ShikiError('Language registrations must be names or registration objects', 'ERR_USAGE')
+  if (typeof registration === "string") return;
+  if (!registration || typeof registration !== "object" || Array.isArray(registration))
+    throw new ShikiError(
+      "Language registrations must be names or registration objects",
+      "ERR_USAGE",
+    );
   const allowed = new Set([
-    'name',
-    'scopeName',
-    'aliases',
-    'patterns',
-    'repository',
-    'injections',
-    'injectionSelector',
-    'fileTypes',
-    'firstLineMatch',
-    '$vscodeTextmateLocation',
-    'embeddedLangs',
-    'embeddedLanguages',
-    'embeddedLangsLazy',
-    'injectTo',
-    'balancedBracketSelectors',
-    'unbalancedBracketSelectors',
-    'displayName',
-    'foldingStopMarker',
-    'foldingStartMarker',
-  ])
+    "name",
+    "scopeName",
+    "aliases",
+    "patterns",
+    "repository",
+    "injections",
+    "injectionSelector",
+    "fileTypes",
+    "firstLineMatch",
+    "$vscodeTextmateLocation",
+    "embeddedLangs",
+    "embeddedLanguages",
+    "embeddedLangsLazy",
+    "injectTo",
+    "balancedBracketSelectors",
+    "unbalancedBracketSelectors",
+    "displayName",
+    "foldingStopMarker",
+    "foldingStartMarker",
+  ]);
   for (const key of Object.keys(registration)) {
     if (!allowed.has(key))
-      throw new ShikiError(`Unsupported language registration field \`${key}\``, 'ERR_USAGE')
+      throw new ShikiError(`Unsupported language registration field \`${key}\``, "ERR_USAGE");
   }
-  if (typeof registration.name !== 'string' || !registration.name)
-    throw new ShikiError('Language registration requires a non-empty `name`', 'ERR_USAGE')
+  if (typeof registration.name !== "string" || !registration.name)
+    throw new ShikiError("Language registration requires a non-empty `name`", "ERR_USAGE");
   if (isCustomLanguageRegistration(registration)) {
-    if (typeof registration.scopeName !== 'string' || !registration.scopeName)
-      throw new ShikiError(`Language registration \`${registration.name}\` requires a non-empty \`scopeName\``, 'ERR_USAGE')
+    if (typeof registration.scopeName !== "string" || !registration.scopeName)
+      throw new ShikiError(
+        `Language registration \`${registration.name}\` requires a non-empty \`scopeName\``,
+        "ERR_USAGE",
+      );
     if (!hasLanguagePayload(registration))
-      throw new ShikiError(`Language registration \`${registration.name}\` has no supported grammar payload`, 'ERR_USAGE')
+      throw new ShikiError(
+        `Language registration \`${registration.name}\` has no supported grammar payload`,
+        "ERR_USAGE",
+      );
   }
-  for (const key of ['aliases', 'embeddedLangs', 'embeddedLanguages', 'embeddedLangsLazy', 'injectTo']) {
-    if (registration[key] !== undefined && (!Array.isArray(registration[key]) || registration[key].some(value => typeof value !== 'string')))
-      throw new ShikiError(`Language registration \`${key}\` must be an array of strings`, 'ERR_USAGE')
+  for (const key of [
+    "aliases",
+    "embeddedLangs",
+    "embeddedLanguages",
+    "embeddedLangsLazy",
+    "injectTo",
+  ]) {
+    if (
+      registration[key] !== undefined &&
+      (!Array.isArray(registration[key]) ||
+        registration[key].some((value) => typeof value !== "string"))
+    )
+      throw new ShikiError(
+        `Language registration \`${key}\` must be an array of strings`,
+        "ERR_USAGE",
+      );
   }
   if (registration.patterns !== undefined && !Array.isArray(registration.patterns))
-    throw new ShikiError('Language registration `patterns` must be an array', 'ERR_USAGE')
-  if (registration.repository !== undefined && (!registration.repository || typeof registration.repository !== 'object' || Array.isArray(registration.repository)))
-    throw new ShikiError('Language registration `repository` must be an object', 'ERR_USAGE')
+    throw new ShikiError("Language registration `patterns` must be an array", "ERR_USAGE");
+  if (
+    registration.repository !== undefined &&
+    (!registration.repository ||
+      typeof registration.repository !== "object" ||
+      Array.isArray(registration.repository))
+  )
+    throw new ShikiError("Language registration `repository` must be an object", "ERR_USAGE");
 }
 
 function validateThemeRegistration(registration) {
-  if (typeof registration === 'string')
-    return
-  if (!registration || typeof registration !== 'object' || Array.isArray(registration))
-    throw new ShikiError('Theme registrations must be names or registration objects', 'ERR_USAGE')
+  if (typeof registration === "string") return;
+  if (!registration || typeof registration !== "object" || Array.isArray(registration))
+    throw new ShikiError("Theme registrations must be names or registration objects", "ERR_USAGE");
   const allowed = new Set([
-    'name',
-    'type',
-    'fg',
-    'bg',
-    'settings',
-    'tokenColors',
-    'colors',
-    'include',
-    'displayName',
-    '$schema',
-    'semanticHighlighting',
-    'semanticTokenColors',
-  ])
+    "name",
+    "type",
+    "fg",
+    "bg",
+    "settings",
+    "tokenColors",
+    "colors",
+    "include",
+    "displayName",
+    "$schema",
+    "semanticHighlighting",
+    "semanticTokenColors",
+  ]);
   for (const key of Object.keys(registration)) {
     if (!allowed.has(key))
-      throw new ShikiError(`Unsupported theme registration field \`${key}\``, 'ERR_USAGE')
+      throw new ShikiError(`Unsupported theme registration field \`${key}\``, "ERR_USAGE");
   }
-  if (typeof registration.name !== 'string' || !registration.name)
-    throw new ShikiError('Theme registration requires a non-empty `name`', 'ERR_USAGE')
-  if (registration.include !== undefined && typeof registration.include !== 'string')
-    throw new ShikiError('Theme registration `include` must be a theme name', 'ERR_USAGE')
-  if (isCustomThemeRegistration(registration) && registration.settings !== undefined && !Array.isArray(registration.settings) && !Array.isArray(registration.tokenColors))
-    throw new ShikiError('Theme registration settings must be an array', 'ERR_USAGE')
+  if (typeof registration.name !== "string" || !registration.name)
+    throw new ShikiError("Theme registration requires a non-empty `name`", "ERR_USAGE");
+  if (registration.include !== undefined && typeof registration.include !== "string")
+    throw new ShikiError("Theme registration `include` must be a theme name", "ERR_USAGE");
+  if (
+    isCustomThemeRegistration(registration) &&
+    registration.settings !== undefined &&
+    !Array.isArray(registration.settings) &&
+    !Array.isArray(registration.tokenColors)
+  )
+    throw new ShikiError("Theme registration settings must be an array", "ERR_USAGE");
   if (!standardThemeKeys.has(registration.name) && !hasThemePayload(registration))
-    throw new ShikiError(`Theme registration \`${registration.name}\` has no supported theme payload`, 'ERR_USAGE')
+    throw new ShikiError(
+      `Theme registration \`${registration.name}\` has no supported theme payload`,
+      "ERR_USAGE",
+    );
 }
 
 function hasLanguagePayload(registration) {
-  return ['patterns', 'repository', 'injections', 'injectionSelector', 'fileTypes', 'firstLineMatch'].some(key => Object.hasOwn(registration, key))
+  return [
+    "patterns",
+    "repository",
+    "injections",
+    "injectionSelector",
+    "fileTypes",
+    "firstLineMatch",
+  ].some((key) => Object.hasOwn(registration, key));
 }
 
 function isCustomLanguageRegistration(registration) {
-  return typeof registration === 'object'
-    && registration !== null
-    && !standardLanguageKeys.has(registration.name)
+  return (
+    typeof registration === "object" &&
+    registration !== null &&
+    !standardLanguageKeys.has(registration.name)
+  );
 }
 
 function hasThemePayload(registration) {
-  return ['settings', 'tokenColors', 'colors', 'fg', 'bg', 'include'].some(key => Object.hasOwn(registration, key))
+  return ["settings", "tokenColors", "colors", "fg", "bg", "include"].some((key) =>
+    Object.hasOwn(registration, key),
+  );
 }
 
 function isCustomThemeRegistration(registration) {
-  return typeof registration === 'object'
-    && registration !== null
-    && !standardThemeKeys.has(registration.name)
+  return (
+    typeof registration === "object" &&
+    registration !== null &&
+    !standardThemeKeys.has(registration.name)
+  );
 }
 
 function isStandardLanguageKey(name) {
-  return standardLanguageKeys.has(name)
+  return standardLanguageKeys.has(name);
 }
 
 function callNativeOperation(message, operation) {
   try {
-    return operation()
-  }
-  catch (cause) {
-    if (cause instanceof ShikiError)
-      throw cause
-    const detail = cause instanceof Error ? cause.message : String(cause)
+    return operation();
+  } catch (cause) {
+    if (cause instanceof ShikiError) throw cause;
+    const detail = cause instanceof Error ? cause.message : String(cause);
     const code = /time|line length|resource|limit/i.test(detail)
-      ? 'ERR_RESOURCE_LIMIT'
+      ? "ERR_RESOURCE_LIMIT"
       : /asset|grammar|theme|catalog/i.test(detail)
-        ? 'ERR_ASSET'
-        : 'ERR_INTERNAL'
-    throw new FerrikiError(`${message}: ${detail}`, code, { cause })
+        ? "ERR_ASSET"
+        : "ERR_INTERNAL";
+    throw new FerrikiError(`${message}: ${detail}`, code, { cause });
   }
 }
 
 function callCustomRegistration(loader, kind) {
   try {
-    return loader()
-  }
-  catch (error) {
-    const detail = error instanceof Error ? error.message : String(error)
-    throw new ShikiError(`Invalid custom ${kind} registration: ${detail}`, 'ERR_ASSET', { cause: error })
+    return loader();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new ShikiError(`Invalid custom ${kind} registration: ${detail}`, "ERR_ASSET", {
+      cause: error,
+    });
   }
 }
 
 function compareIds(left, right) {
-  return left < right ? -1 : left > right ? 1 : 0
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 function hasThemes(options) {
-  return options != null && Object.hasOwn(options, 'themes')
+  return options != null && Object.hasOwn(options, "themes");
 }
 
 function resolveThemeEntries(options) {
   const entries = Object.entries(options?.themes || {})
     .filter(([, theme]) => theme != null && theme !== false)
-    .map(([color, theme]) => ({ color, input: theme, name: registrationName(theme) }))
-  if (entries.length === 0)
-    throw new ShikiError('`themes` option must not be empty', 'ERR_USAGE')
-  if (entries.some(entry => !entry.name))
-    throw new ShikiError('Theme registrations must provide a name', 'ERR_USAGE')
+    .map(([color, theme]) => ({ color, input: theme, name: registrationName(theme) }));
+  if (entries.length === 0) throw new ShikiError("`themes` option must not be empty", "ERR_USAGE");
+  if (entries.some((entry) => !entry.name))
+    throw new ShikiError("Theme registrations must provide a name", "ERR_USAGE");
 
-  const defaultColor = options.defaultColor === undefined ? 'light' : options.defaultColor
-  if (defaultColor && defaultColor !== 'light-dark()') {
-    const defaultEntry = entries.find(entry => entry.color === defaultColor)
+  const defaultColor = options.defaultColor === undefined ? "light" : options.defaultColor;
+  if (defaultColor && defaultColor !== "light-dark()") {
+    const defaultEntry = entries.find((entry) => entry.color === defaultColor);
     if (!defaultEntry)
-      throw new ShikiError(`\`themes\` option must contain the defaultColor key \`${defaultColor}\``, 'ERR_USAGE')
-    return [defaultEntry, ...entries.filter(entry => entry !== defaultEntry)]
+      throw new ShikiError(
+        `\`themes\` option must contain the defaultColor key \`${defaultColor}\``,
+        "ERR_USAGE",
+      );
+    return [defaultEntry, ...entries.filter((entry) => entry !== defaultEntry)];
   }
-  if (defaultColor === 'light-dark()' && (
-    !entries.some(entry => entry.color === 'light')
-    || !entries.some(entry => entry.color === 'dark')
-  )) {
-    throw new ShikiError('When using `defaultColor: "light-dark()"`, you must provide both `light` and `dark` themes', 'ERR_USAGE')
+  if (
+    defaultColor === "light-dark()" &&
+    (!entries.some((entry) => entry.color === "light") ||
+      !entries.some((entry) => entry.color === "dark"))
+  ) {
+    throw new ShikiError(
+      'When using `defaultColor: "light-dark()"`, you must provide both `light` and `dark` themes',
+      "ERR_USAGE",
+    );
   }
-  return entries
+  return entries;
 }
 
 function normalizeNoneThemeResult(result) {
   return {
     ...result,
-    fg: 'inherit',
-    bg: 'inherit',
-    themeName: 'none',
-    tokens: result.tokens.map(line => line.map(token => ({
-      content: token.content,
-      offset: token.offset,
-      ...(token.type === undefined ? {} : { type: token.type }),
-      ...(token.scopeNames ? { scopeNames: token.scopeNames } : {}),
-    }))),
-  }
+    fg: "inherit",
+    bg: "inherit",
+    themeName: "none",
+    tokens: result.tokens.map((line) =>
+      line.map((token) => ({
+        content: token.content,
+        offset: token.offset,
+        ...(token.type === undefined ? {} : { type: token.type }),
+        ...(token.scopeNames ? { scopeNames: token.scopeNames } : {}),
+      })),
+    ),
+  };
 }
 
 function combineThemeResults(results, options) {
-  const defaultColor = options.defaultColor === undefined ? 'light' : options.defaultColor
-  const cssVariablePrefix = options.cssVariablePrefix || '--shiki-'
-  const tokens = alignThemeTokens(results).map(line => line.map(token => ({
-    ...token,
-    htmlStyle: tokenHtmlStyle(token.variants, results, defaultColor, cssVariablePrefix),
-  })))
-  const foreground = themePropertyStyle(results, 'foreground', defaultColor, cssVariablePrefix)
-  const background = themePropertyStyle(results, 'background', defaultColor, cssVariablePrefix)
+  const defaultColor = options.defaultColor === undefined ? "light" : options.defaultColor;
+  const cssVariablePrefix = options.cssVariablePrefix || "--shiki-";
+  const tokens = alignThemeTokens(results).map((line) =>
+    line.map((token) => ({
+      ...token,
+      htmlStyle: tokenHtmlStyle(token.variants, results, defaultColor, cssVariablePrefix),
+    })),
+  );
+  const foreground = themePropertyStyle(results, "foreground", defaultColor, cssVariablePrefix);
+  const background = themePropertyStyle(results, "background", defaultColor, cssVariablePrefix);
   return {
     tokens,
     fg: foreground,
     bg: background,
-    themeName: `shiki-themes ${results.map(result => result.name).join(' ')}`,
+    themeName: `shiki-themes ${results.map((result) => result.name).join(" ")}`,
     ...(defaultColor ? {} : { rootStyle: `${foreground};${background}` }),
-  }
+  };
 }
 
 function combineNativeThemeResult(result, options) {
-  const results = result.themes.map(theme => ({
+  const results = result.themes.map((theme) => ({
     color: theme.color,
     name: theme.name,
     result: {
       fg: theme.foreground,
       bg: theme.background,
     },
-  }))
-  const defaultColor = options.defaultColor === undefined ? 'light' : options.defaultColor
-  const cssVariablePrefix = options.cssVariablePrefix || '--shiki-'
-  const tokens = result.tokens.map(line => line.map((token) => {
-    const variants = Object.fromEntries(Object.entries(token.variants).map(([color, style]) => [
-      color,
-      tokenStyleFromNative(style),
-    ]))
-    return {
-      content: token.content,
-      offset: token.offset,
-      ...(token.type === undefined ? {} : { type: token.type }),
-      ...(token.scopeNames ? { scopeNames: token.scopeNames } : {}),
-      variants,
-      htmlStyle: tokenHtmlStyle(variants, results, defaultColor, cssVariablePrefix),
-    }
-  }))
-  const foreground = themePropertyStyle(results, 'foreground', defaultColor, cssVariablePrefix)
-  const background = themePropertyStyle(results, 'background', defaultColor, cssVariablePrefix)
+  }));
+  const defaultColor = options.defaultColor === undefined ? "light" : options.defaultColor;
+  const cssVariablePrefix = options.cssVariablePrefix || "--shiki-";
+  const tokens = result.tokens.map((line) =>
+    line.map((token) => {
+      const variants = Object.fromEntries(
+        Object.entries(token.variants).map(([color, style]) => [
+          color,
+          tokenStyleFromNative(style),
+        ]),
+      );
+      return {
+        content: token.content,
+        offset: token.offset,
+        ...(token.type === undefined ? {} : { type: token.type }),
+        ...(token.scopeNames ? { scopeNames: token.scopeNames } : {}),
+        variants,
+        htmlStyle: tokenHtmlStyle(variants, results, defaultColor, cssVariablePrefix),
+      };
+    }),
+  );
+  const foreground = themePropertyStyle(results, "foreground", defaultColor, cssVariablePrefix);
+  const background = themePropertyStyle(results, "background", defaultColor, cssVariablePrefix);
   return {
     tokens,
     fg: foreground,
     bg: background,
-    themeName: `shiki-themes ${results.map(result => result.name).join(' ')}`,
+    themeName: `shiki-themes ${results.map((result) => result.name).join(" ")}`,
     ...(defaultColor ? {} : { rootStyle: `${foreground};${background}` }),
-  }
+  };
 }
 
 function tokenStyleFromNative(style) {
-  const output = {}
-  if (style.color)
-    output.color = style.color
-  const fontStyle = style.fontStyle || 0
-  if (fontStyle & 1)
-    output['font-style'] = 'italic'
-  if (fontStyle & 2)
-    output['font-weight'] = 'bold'
-  const decorations = []
-  if (fontStyle & 4)
-    decorations.push('underline')
-  if (fontStyle & 8)
-    decorations.push('line-through')
-  if (decorations.length)
-    output['text-decoration'] = decorations.join(' ')
-  return output
+  const output = {};
+  if (style.color) output.color = style.color;
+  const fontStyle = style.fontStyle || 0;
+  if (fontStyle & 1) output["font-style"] = "italic";
+  if (fontStyle & 2) output["font-weight"] = "bold";
+  const decorations = [];
+  if (fontStyle & 4) decorations.push("underline");
+  if (fontStyle & 8) decorations.push("line-through");
+  if (decorations.length) output["text-decoration"] = decorations.join(" ");
+  return output;
 }
 
 function alignThemeTokens(results) {
-  const lineCount = Math.max(...results.map(result => result.result.tokens.length))
+  const lineCount = Math.max(...results.map((result) => result.result.tokens.length));
   return Array.from({ length: lineCount }, (_, lineIndex) => {
-    const lines = results.map(result => result.result.tokens[lineIndex] || [])
-    const boundaries = new Set()
+    const lines = results.map((result) => result.result.tokens[lineIndex] || []);
+    const boundaries = new Set();
     for (const line of lines) {
       for (const token of line) {
-        boundaries.add(token.offset)
-        boundaries.add(token.offset + token.content.length)
+        boundaries.add(token.offset);
+        boundaries.add(token.offset + token.content.length);
       }
     }
-    const sorted = [...boundaries].sort((left, right) => left - right)
-    const output = []
+    const sorted = [...boundaries].sort((left, right) => left - right);
+    const output = [];
     for (let index = 0; index < sorted.length - 1; index++) {
-      const start = sorted[index]
-      const end = sorted[index + 1]
-      if (start === end)
-        continue
-      const variants = {}
-      let baseToken
+      const start = sorted[index];
+      const end = sorted[index + 1];
+      if (start === end) continue;
+      const variants = {};
+      let baseToken;
       for (const result of results) {
-        const token = tokenAt(lines[results.indexOf(result)], start)
-        if (token && !baseToken)
-          baseToken = token
-        variants[result.color] = tokenStyle(token)
+        const token = tokenAt(lines[results.indexOf(result)], start);
+        if (token && !baseToken) baseToken = token;
+        variants[result.color] = tokenStyle(token);
       }
-      if (!baseToken)
-        continue
+      if (!baseToken) continue;
       output.push({
         content: baseToken.content.slice(start - baseToken.offset, end - baseToken.offset),
         offset: start,
         ...(baseToken.type === undefined ? {} : { type: baseToken.type }),
         ...(baseToken.scopeNames ? { scopeNames: baseToken.scopeNames } : {}),
         variants,
-      })
+      });
     }
-    return output
-  })
+    return output;
+  });
 }
 
 function tokenAt(line, offset) {
-  return line.find(token => offset >= token.offset && offset < token.offset + token.content.length)
+  return line.find(
+    (token) => offset >= token.offset && offset < token.offset + token.content.length,
+  );
 }
 
 function tokenStyle(token) {
-  if (!token)
-    return {}
-  const style = {}
-  if (token.color)
-    style.color = token.color
-  const fontStyle = token.fontStyle || 0
-  if (fontStyle & 1)
-    style['font-style'] = 'italic'
-  if (fontStyle & 2)
-    style['font-weight'] = 'bold'
-  const decorations = []
-  if (fontStyle & 4)
-    decorations.push('underline')
-  if (fontStyle & 8)
-    decorations.push('line-through')
-  if (decorations.length)
-    style['text-decoration'] = decorations.join(' ')
-  return style
+  if (!token) return {};
+  const style = {};
+  if (token.color) style.color = token.color;
+  const fontStyle = token.fontStyle || 0;
+  if (fontStyle & 1) style["font-style"] = "italic";
+  if (fontStyle & 2) style["font-weight"] = "bold";
+  const decorations = [];
+  if (fontStyle & 4) decorations.push("underline");
+  if (fontStyle & 8) decorations.push("line-through");
+  if (decorations.length) style["text-decoration"] = decorations.join(" ");
+  return style;
 }
 
 function tokenHtmlStyle(variants, results, defaultColor, cssVariablePrefix) {
-  const styles = results.map(result => variants[result.color] || {})
-  const keys = new Set(styles.flatMap(style => Object.keys(style)))
-  const declarations = []
+  const styles = results.map((result) => variants[result.color] || {});
+  const keys = new Set(styles.flatMap((style) => Object.keys(style)));
+  const declarations = [];
   for (const key of keys) {
     for (let index = 0; index < results.length; index++) {
-      const value = styles[index][key] || 'inherit'
-      const color = results[index].color
+      const value = styles[index][key] || "inherit";
+      const color = results[index].color;
       if (index === 0 && defaultColor) {
-        if (defaultColor === 'light-dark()' && (key === 'color' || key === 'background-color')) {
-          const lightIndex = results.findIndex(result => result.color === 'light')
-          const darkIndex = results.findIndex(result => result.color === 'dark')
+        if (defaultColor === "light-dark()" && (key === "color" || key === "background-color")) {
+          const lightIndex = results.findIndex((result) => result.color === "light");
+          const darkIndex = results.findIndex((result) => result.color === "dark");
           if (lightIndex !== -1 && darkIndex !== -1) {
-            const light = styles[lightIndex][key] || 'inherit'
-            const dark = styles[darkIndex][key] || 'inherit'
-            declarations.push(`${key}:light-dark(${light}, ${dark})`)
+            const light = styles[lightIndex][key] || "inherit";
+            const dark = styles[darkIndex][key] || "inherit";
+            declarations.push(`${key}:light-dark(${light}, ${dark})`);
           }
-        }
-        else {
-          declarations.push(`${key}:${value}`)
+        } else {
+          declarations.push(`${key}:${value}`);
         }
       }
-      if (index > 0 || !defaultColor || defaultColor === 'light-dark()') {
-        const suffix = key === 'color' ? '' : key === 'background-color' ? '-bg' : `-${key}`
-        declarations.push(`${cssVariablePrefix}${color}${suffix}:${value}`)
+      if (index > 0 || !defaultColor || defaultColor === "light-dark()") {
+        const suffix = key === "color" ? "" : key === "background-color" ? "-bg" : `-${key}`;
+        declarations.push(`${cssVariablePrefix}${color}${suffix}:${value}`);
       }
     }
   }
-  return declarations.join(';')
+  return declarations.join(";");
 }
 
 function themePropertyStyle(results, property, defaultColor, cssVariablePrefix) {
-  const declarations = []
+  const declarations = [];
   for (let index = 0; index < results.length; index++) {
-    const value = results[index].result[property === 'foreground' ? 'fg' : 'bg'] || 'inherit'
-    const color = results[index].color
+    const value = results[index].result[property === "foreground" ? "fg" : "bg"] || "inherit";
+    const color = results[index].color;
     if (index === 0 && defaultColor) {
-      if (defaultColor === 'light-dark()') {
-        const light = results.find(result => result.color === 'light')?.result[property === 'foreground' ? 'fg' : 'bg'] || 'inherit'
-        const dark = results.find(result => result.color === 'dark')?.result[property === 'foreground' ? 'fg' : 'bg'] || 'inherit'
-        declarations.push(`light-dark(${light}, ${dark})`)
-      }
-      else {
-        declarations.push(value)
+      if (defaultColor === "light-dark()") {
+        const light =
+          results.find((result) => result.color === "light")?.result[
+            property === "foreground" ? "fg" : "bg"
+          ] || "inherit";
+        const dark =
+          results.find((result) => result.color === "dark")?.result[
+            property === "foreground" ? "fg" : "bg"
+          ] || "inherit";
+        declarations.push(`light-dark(${light}, ${dark})`);
+      } else {
+        declarations.push(value);
       }
     }
-    if (index > 0 || !defaultColor || defaultColor === 'light-dark()')
-      declarations.push(`${cssVariablePrefix}${color}${property === 'background' ? '-bg' : ''}:${value}`)
+    if (index > 0 || !defaultColor || defaultColor === "light-dark()")
+      declarations.push(
+        `${cssVariablePrefix}${color}${property === "background" ? "-bg" : ""}:${value}`,
+      );
   }
-  return declarations.join(';')
+  return declarations.join(";");
 }
 
 function renderTokenResultHast(result, options = {}) {
   const properties = {
     class: result.themeName,
-  }
+  };
   if (options.rootStyle !== false) {
-    properties.style = options.rootStyle || result.rootStyle || `background-color:${result.bg};color:${result.fg}`
+    properties.style =
+      options.rootStyle || result.rootStyle || `background-color:${result.bg};color:${result.fg}`;
   }
   if (options.tabindex !== false && options.tabindex !== null)
-    properties.tabindex = String(options.tabindex ?? 0)
-  const children = []
+    properties.tabindex = String(options.tabindex ?? 0);
+  const children = [];
   for (let lineIndex = 0; lineIndex < result.tokens.length; lineIndex++) {
-    if (lineIndex > 0)
-      children.push({ type: 'text', value: '\n' })
+    if (lineIndex > 0) children.push({ type: "text", value: "\n" });
     children.push({
-      type: 'element',
-      tagName: 'span',
-      properties: { class: 'line' },
-      children: result.tokens[lineIndex].map(token => ({
-        type: 'element',
-        tagName: 'span',
+      type: "element",
+      tagName: "span",
+      properties: { class: "line" },
+      children: result.tokens[lineIndex].map((token) => ({
+        type: "element",
+        tagName: "span",
         properties: token.htmlStyle ? { style: token.htmlStyle } : {},
-        children: [{ type: 'text', value: token.content }],
+        children: [{ type: "text", value: token.content }],
       })),
-    })
+    });
   }
   return {
-    type: 'root',
-    children: [{
-      type: 'element',
-      tagName: 'pre',
-      properties,
-      children: [{
-        type: 'element',
-        tagName: 'code',
-        properties: {},
-        children,
-      }],
-    }],
-  }
+    type: "root",
+    children: [
+      {
+        type: "element",
+        tagName: "pre",
+        properties,
+        children: [
+          {
+            type: "element",
+            tagName: "code",
+            properties: {},
+            children,
+          },
+        ],
+      },
+    ],
+  };
 }
 
 function hasHastPipeline(options) {
   return Boolean(
-    options?.decorations
-    || options?.structure
-    || options?.meta
-    || options?.data
-    || options?.transformers?.length,
-  )
+    options?.decorations ||
+    options?.structure ||
+    options?.meta ||
+    options?.data ||
+    options?.transformers?.length,
+  );
 }
 
 function applyPostprocess(html, options, source) {
-  let output = html
-  const context = { meta: {}, options, source }
+  let output = html;
+  const context = { meta: {}, options, source };
   for (const transformer of sortTransformers(options?.transformers))
-    output = transformer?.postprocess?.call(context, output, options) || output
-  return output
+    output = transformer?.postprocess?.call(context, output, options) || output;
+  return output;
 }
 
 function selectDefaultTheme(options) {
-  if (!options.themes)
-    return undefined
+  if (!options.themes) return undefined;
   if (options.defaultColor && options.themes[options.defaultColor])
-    return options.themes[options.defaultColor]
-  return options.themes.light || options.themes.dark || Object.values(options.themes)[0]
+    return options.themes[options.defaultColor];
+  return options.themes.light || options.themes.dark || Object.values(options.themes)[0];
 }
 
 function isHighlighter(value, method) {
-  return value != null && typeof value[method] === 'function'
+  return value != null && typeof value[method] === "function";
 }
 
 function isSpecialLanguage(language) {
-  return ['text', 'txt', 'plain', 'plaintext', 'ansi'].includes(language)
+  return ["text", "txt", "plain", "plaintext", "ansi"].includes(language);
 }
 
 function scopeNameForLanguage(language) {
-  return languageCatalog.find(entry => entry.id === language || entry.aliases.includes(language))?.scopeName
-    || `source.${language}`
+  return (
+    languageCatalog.find((entry) => entry.id === language || entry.aliases.includes(language))
+      ?.scopeName || `source.${language}`
+  );
 }
 
 function assertAnsiInput(code, options) {
-  if (!globalThis.__FERRIKI_COMPAT_LEGACY_ANSI
-    && registrationName(options?.lang) === 'ansi'
-    && code.includes(String.fromCharCode(27))) {
-    throw new ShikiError('ANSI control sequences are not supported by Ferriki; strip or parse them before highlighting', 'ERR_UNSUPPORTED')
+  if (
+    !globalThis.__FERRIKI_COMPAT_LEGACY_ANSI &&
+    registrationName(options?.lang) === "ansi" &&
+    code.includes(String.fromCharCode(27))
+  ) {
+    throw new ShikiError(
+      "ANSI control sequences are not supported by Ferriki; strip or parse them before highlighting",
+      "ERR_UNSUPPORTED",
+    );
   }
 }
 
 function registrationName(registration) {
-  if (typeof registration === 'string')
-    return registration
-  return registration?.name || registration?.id
+  if (typeof registration === "string") return registration;
+  return registration?.name || registration?.id;
 }
 
 function resolveSyncRegistrations(inputs) {
   return inputs.flat(Infinity).flatMap((input) => {
-    if (typeof input === 'function' || input?.then)
-      throw new ShikiError('Async language/theme input requires the async loader', 'ERR_USAGE')
-    if (input?.default)
-      return resolveSyncRegistrations([input.default])
-    return input == null ? [] : [input]
-  })
+    if (typeof input === "function" || input?.then)
+      throw new ShikiError("Async language/theme input requires the async loader", "ERR_USAGE");
+    if (input?.default) return resolveSyncRegistrations([input.default]);
+    return input == null ? [] : [input];
+  });
 }
 
 async function resolveRegistrations(inputs) {
-  const output = []
+  const output = [];
   for (let input of inputs.flat(Infinity)) {
-    if (typeof input === 'function')
-      input = input()
-    input = await input
-    if (input?.default)
-      input = input.default
-    if (Array.isArray(input))
-      output.push(...await resolveRegistrations(input))
-    else if (input != null)
-      output.push(input)
+    if (typeof input === "function") input = input();
+    input = await input;
+    if (input?.default) input = input.default;
+    if (Array.isArray(input)) output.push(...(await resolveRegistrations(input)));
+    else if (input != null) output.push(input);
   }
-  return output
+  return output;
 }
 
 function nodeToHtml(node) {
-  if (node.type === 'text')
-    return escapeHtml(node.value || '')
-  if (node.type !== 'element')
-    return (node.children || []).map(nodeToHtml).join('')
+  if (node.type === "text") return escapeHtml(node.value || "");
+  if (node.type !== "element") return (node.children || []).map(nodeToHtml).join("");
   const properties = Object.entries(node.properties || {})
     .map(([key, value]) => ` ${key}="${escapeAttribute(propertyValue(value))}"`)
-    .join('')
-  return `<${node.tagName}${properties}>${(node.children || []).map(nodeToHtml).join('')}</${node.tagName}>`
+    .join("");
+  return `<${node.tagName}${properties}>${(node.children || []).map(nodeToHtml).join("")}</${node.tagName}>`;
 }
 
 function propertyValue(value) {
-  if (Array.isArray(value))
-    return value.join(' ')
-  if (value && typeof value === 'object')
-    return Object.entries(value).map(([key, entry]) => `${key}:${entry}`).join(';')
-  return String(value)
+  if (Array.isArray(value)) return value.join(" ");
+  if (value && typeof value === "object")
+    return Object.entries(value)
+      .map(([key, entry]) => `${key}:${entry}`)
+      .join(";");
+  return String(value);
 }
 
 function escapeHtml(value) {
-  return value.replaceAll('&', '&#x26;').replaceAll('<', '&#x3C;')
+  return value.replaceAll("&", "&#x26;").replaceAll("<", "&#x3C;");
 }
 
 function escapeAttribute(value) {
-  return escapeHtml(value).replaceAll('"', '&#x22;')
+  return escapeHtml(value).replaceAll('"', "&#x22;");
 }

--- a/node/ferriki/transformers.mjs
+++ b/node/ferriki/transformers.mjs
@@ -1,302 +1,328 @@
-import { ShikiError } from './index.mjs'
+import { ShikiError } from "./index.mjs";
 
 export function sortTransformers(transformers) {
-  if (transformers === undefined)
-    return []
+  if (transformers === undefined) return [];
   if (!Array.isArray(transformers))
-    throw new ShikiError('Highlight option transformers must be an array', 'ERR_USAGE')
-  return [...transformers].sort((left, right) => rank(left) - rank(right))
+    throw new ShikiError("Highlight option transformers must be an array", "ERR_USAGE");
+  return [...transformers].sort((left, right) => rank(left) - rank(right));
 }
 
 function rank(transformer) {
-  return transformer?.enforce === 'pre' ? -1 : transformer?.enforce === 'post' ? 1 : 0
+  return transformer?.enforce === "pre" ? -1 : transformer?.enforce === "post" ? 1 : 0;
 }
 
 export function applyTokenTransformers(tokens, transformers, context) {
-  let result = tokens
+  let result = tokens;
   for (const transformer of transformers)
-    result = transformer?.tokens?.call(context, result) || result
-  return result
+    result = transformer?.tokens?.call(context, result) || result;
+  return result;
 }
 
 export function renderTransformedHast(result, options, transformers, commonContext, source) {
   const properties = {
     class: result.themeName,
-  }
+  };
   if (options.rootStyle !== false)
-    properties.style = options.rootStyle || result.rootStyle || (`background-color:${result.bg};color:${result.fg}`)
+    properties.style =
+      options.rootStyle || result.rootStyle || `background-color:${result.bg};color:${result.fg}`;
   if (options.tabindex !== false && options.tabindex !== null)
-    properties.tabindex = String(options.tabindex ?? 0)
+    properties.tabindex = String(options.tabindex ?? 0);
   for (const [key, value] of Object.entries(options.meta || {})) {
-    if (!key.startsWith('_'))
-      properties[key] = value
+    if (!key.startsWith("_")) properties[key] = value;
   }
 
-  const root = { type: 'root', children: [] }
-  const lines = []
-  let preNode
-  let codeNode
+  const root = { type: "root", children: [] };
+  const lines = [];
+  let preNode;
+  let codeNode;
   const context = {
     ...commonContext,
     source,
     options,
-    structure: options.structure || 'classic',
+    structure: options.structure || "classic",
     root,
     get tokens() {
-      return result.tokens
+      return result.tokens;
     },
     get pre() {
-      return preNode
+      return preNode;
     },
     get code() {
-      return codeNode
+      return codeNode;
     },
     get lines() {
-      return lines
+      return lines;
     },
     addClassToHast,
-  }
+  };
 
   for (let lineIndex = 0; lineIndex < result.tokens.length; lineIndex++) {
     const lineNode = {
-      type: 'element',
-      tagName: 'span',
-      properties: { class: 'line' },
+      type: "element",
+      tagName: "span",
+      properties: { class: "line" },
       children: [],
-    }
+    };
     for (let column = 0; column < result.tokens[lineIndex].length; column++) {
-      const token = result.tokens[lineIndex][column]
+      const token = result.tokens[lineIndex][column];
       let span = {
-        type: 'element',
-        tagName: 'span',
+        type: "element",
+        tagName: "span",
         properties: {
           ...(token.htmlAttrs || {}),
           ...(token.htmlStyle ? { style: stringifyStyle(token.htmlStyle) } : {}),
         },
-        children: [{ type: 'text', value: token.content }],
-      }
+        children: [{ type: "text", value: token.content }],
+      };
       for (const transformer of transformers)
-        span = transformer?.span?.call(context, span, lineIndex + 1, column, lineNode, token) || span
-      lineNode.children.push(span)
+        span =
+          transformer?.span?.call(context, span, lineIndex + 1, column, lineNode, token) || span;
+      lineNode.children.push(span);
     }
-    let transformedLine = lineNode
+    let transformedLine = lineNode;
     for (const transformer of transformers)
-      transformedLine = transformer?.line?.call(context, transformedLine, lineIndex + 1) || transformedLine
-    lines.push(transformedLine)
+      transformedLine =
+        transformer?.line?.call(context, transformedLine, lineIndex + 1) || transformedLine;
+    lines.push(transformedLine);
   }
 
-  if (context.structure === 'inline') {
+  if (context.structure === "inline") {
     for (let index = 0; index < lines.length; index++) {
       if (index > 0)
-        root.children.push({ type: 'element', tagName: 'br', properties: {}, children: [] })
-      root.children.push(...lines[index].children)
+        root.children.push({ type: "element", tagName: "br", properties: {}, children: [] });
+      root.children.push(...lines[index].children);
     }
     codeNode = {
-      type: 'element',
-      tagName: 'code',
+      type: "element",
+      tagName: "code",
       properties: {},
       children: lines,
-    }
-  }
-  else {
-    const children = []
+    };
+  } else {
+    const children = [];
     for (let index = 0; index < lines.length; index++) {
-      if (index > 0)
-        children.push({ type: 'text', value: '\n' })
-      children.push(lines[index])
+      if (index > 0) children.push({ type: "text", value: "\n" });
+      children.push(lines[index]);
     }
     codeNode = {
-      type: 'element',
-      tagName: 'code',
+      type: "element",
+      tagName: "code",
       properties: {},
       children,
-    }
+    };
     preNode = {
-      type: 'element',
-      tagName: 'pre',
+      type: "element",
+      tagName: "pre",
       properties,
       children: [codeNode],
       data: options.data,
-    }
+    };
   }
 
-  if (context.structure === 'classic') {
+  if (context.structure === "classic") {
     for (const transformer of transformers)
-      codeNode = transformer?.code?.call(context, codeNode) || codeNode
-    preNode.children = [codeNode]
+      codeNode = transformer?.code?.call(context, codeNode) || codeNode;
+    preNode.children = [codeNode];
     for (const transformer of transformers)
-      preNode = transformer?.pre?.call(context, preNode) || preNode
-    root.children.push(preNode)
-  }
-  else {
+      preNode = transformer?.pre?.call(context, preNode) || preNode;
+    root.children.push(preNode);
+  } else {
     for (const transformer of transformers)
-      codeNode = transformer?.code?.call(context, codeNode) || codeNode
+      codeNode = transformer?.code?.call(context, codeNode) || codeNode;
   }
 
-  if (options.decorations?.length)
-    applyDecorations(codeNode, options.decorations, source)
-  if (context.structure === 'inline' && options.decorations?.length) {
-    root.children = []
+  if (options.decorations?.length) applyDecorations(codeNode, options.decorations, source);
+  if (context.structure === "inline" && options.decorations?.length) {
+    root.children = [];
     for (let index = 0; index < lines.length; index++) {
       if (index > 0)
-        root.children.push({ type: 'element', tagName: 'br', properties: {}, children: [] })
-      root.children.push(...lines[index].children)
+        root.children.push({ type: "element", tagName: "br", properties: {}, children: [] });
+      root.children.push(...lines[index].children);
     }
   }
 
-  let output = root
+  let output = root;
   for (const transformer of transformers)
-    output = transformer?.root?.call(context, output) || output
-  return output
+    output = transformer?.root?.call(context, output) || output;
+  return output;
 }
 
 function addClassToHast(node, className) {
-  const current = node.properties?.class
+  const current = node.properties?.class;
   const currentClasses = Array.isArray(current)
     ? current
-    : typeof current === 'string' ? current.split(/\s+/).filter(Boolean) : []
-  const addedClasses = Array.isArray(className) ? className : [className]
+    : typeof current === "string"
+      ? current.split(/\s+/).filter(Boolean)
+      : [];
+  const addedClasses = Array.isArray(className) ? className : [className];
   node.properties = {
     ...(node.properties || {}),
-    class: [...new Set([...currentClasses, ...addedClasses])].join(' '),
-  }
-  return node
+    class: [...new Set([...currentClasses, ...addedClasses])].join(" "),
+  };
+  return node;
 }
 
 function stringifyStyle(style) {
-  if (typeof style === 'string')
-    return style
-  if (!style || typeof style !== 'object')
-    return String(style || '')
-  return Object.entries(style).map(([key, value]) => `${key}:${value}`).join(';')
+  if (typeof style === "string") return style;
+  if (!style || typeof style !== "object") return String(style || "");
+  return Object.entries(style)
+    .map(([key, value]) => `${key}:${value}`)
+    .join(";");
 }
 
 export function splitTokensAtDecorations(tokens, decorations, source) {
-  const resolved = resolveDecorations(decorations, source)
-  const breakpoints = resolved.flatMap(item => [item.start.offset, item.end.offset])
-  return tokens.map(line => line.flatMap((token) => {
-    const start = token.offset
-    const end = start + token.content.length
-    const points = [...new Set([
-      start,
-      ...breakpoints.filter(point => point > start && point < end),
-      end,
-    ])].sort((left, right) => left - right)
-    return points.slice(0, -1).map((point, index) => ({
-      ...token,
-      offset: point,
-      content: token.content.slice(point - start, points[index + 1] - start),
-    }))
-  }))
+  const resolved = resolveDecorations(decorations, source);
+  const breakpoints = resolved.flatMap((item) => [item.start.offset, item.end.offset]);
+  return tokens.map((line) =>
+    line.flatMap((token) => {
+      const start = token.offset;
+      const end = start + token.content.length;
+      const points = [
+        ...new Set([start, ...breakpoints.filter((point) => point > start && point < end), end]),
+      ].sort((left, right) => left - right);
+      return points.slice(0, -1).map((point, index) => ({
+        ...token,
+        offset: point,
+        content: token.content.slice(point - start, points[index + 1] - start),
+      }));
+    }),
+  );
 }
 
 function resolveDecorations(decorations, source) {
-  const sourceLines = source.split('\n')
-  const lineStarts = []
-  let offset = 0
+  const sourceLines = source.split("\n");
+  const lineStarts = [];
+  let offset = 0;
   for (const line of sourceLines) {
-    lineStarts.push(offset)
-    offset += line.length + 1
+    lineStarts.push(offset);
+    offset += line.length + 1;
   }
-  const lineLength = line => line.endsWith('\r') ? line.length - 1 : line.length
+  const lineLength = (line) => (line.endsWith("\r") ? line.length - 1 : line.length);
   const toPosition = (value) => {
-    if (typeof value === 'number') {
+    if (typeof value === "number") {
       if (value < 0 || value > source.length)
-        throw new ShikiError(`Invalid decoration offset: ${value}. Code length: ${source.length}`, 'ERR_USAGE')
-      let line = 0
-      while (line + 1 < lineStarts.length && lineStarts[line + 1] <= value)
-        line++
-      return { line, character: value - lineStarts[line], offset: value }
+        throw new ShikiError(
+          `Invalid decoration offset: ${value}. Code length: ${source.length}`,
+          "ERR_USAGE",
+        );
+      let line = 0;
+      while (line + 1 < lineStarts.length && lineStarts[line + 1] <= value) line++;
+      return { line, character: value - lineStarts[line], offset: value };
     }
-    const line = sourceLines[value?.line] === undefined ? -1 : value.line
+    const line = sourceLines[value?.line] === undefined ? -1 : value.line;
     if (line < 0)
-      throw new ShikiError(`Invalid decoration position ${JSON.stringify(value)}. Lines length: ${sourceLines.length}`, 'ERR_USAGE')
-    let character = value.character
-    if (character < 0)
-      character = lineLength(sourceLines[line]) + character
+      throw new ShikiError(
+        `Invalid decoration position ${JSON.stringify(value)}. Lines length: ${sourceLines.length}`,
+        "ERR_USAGE",
+      );
+    let character = value.character;
+    if (character < 0) character = lineLength(sourceLines[line]) + character;
     if (character < 0 || character > lineLength(sourceLines[line]))
-      throw new ShikiError(`Invalid decoration position ${JSON.stringify(value)}. Line ${line} length: ${lineLength(sourceLines[line])}`, 'ERR_USAGE')
-    return { line, character, offset: lineStarts[line] + character }
-  }
-  const items = decorations.map(decoration => ({
+      throw new ShikiError(
+        `Invalid decoration position ${JSON.stringify(value)}. Line ${line} length: ${lineLength(sourceLines[line])}`,
+        "ERR_USAGE",
+      );
+    return { line, character, offset: lineStarts[line] + character };
+  };
+  const items = decorations.map((decoration) => ({
     ...decoration,
     start: toPosition(decoration.start),
     end: toPosition(decoration.end),
-  }))
+  }));
   for (let index = 0; index < items.length; index++) {
-    const current = items[index]
+    const current = items[index];
     if (current.start.offset > current.end.offset)
-      throw new ShikiError(`Invalid decoration range: ${JSON.stringify(current.start)} - ${JSON.stringify(current.end)}`, 'ERR_USAGE')
+      throw new ShikiError(
+        `Invalid decoration range: ${JSON.stringify(current.start)} - ${JSON.stringify(current.end)}`,
+        "ERR_USAGE",
+      );
     for (const other of items.slice(index + 1)) {
-      const nested = (current.start.offset <= other.start.offset && other.end.offset <= current.end.offset)
-        || (other.start.offset <= current.start.offset && current.end.offset <= other.end.offset)
-      const intersects = current.start.offset < other.end.offset && other.start.offset < current.end.offset
+      const nested =
+        (current.start.offset <= other.start.offset && other.end.offset <= current.end.offset) ||
+        (other.start.offset <= current.start.offset && current.end.offset <= other.end.offset);
+      const intersects =
+        current.start.offset < other.end.offset && other.start.offset < current.end.offset;
       if (intersects && !nested)
-        throw new ShikiError(`Decorations ${JSON.stringify(current.start)} and ${JSON.stringify(other.start)} intersect.`, 'ERR_USAGE')
+        throw new ShikiError(
+          `Decorations ${JSON.stringify(current.start)} and ${JSON.stringify(other.start)} intersect.`,
+          "ERR_USAGE",
+        );
     }
   }
-  return items
+  return items;
 }
 
 function applyDecorations(codeNode, decorations, source) {
-  const items = resolveDecorations(decorations, source)
-  const lines = (codeNode.children || []).filter(node => node.type === 'element' && node.tagName === 'span')
+  const items = resolveDecorations(decorations, source);
+  const lines = (codeNode.children || []).filter(
+    (node) => node.type === "element" && node.tagName === "span",
+  );
   const applyProperties = (node, decoration, type) => {
-    node.tagName = decoration.tagName || 'span'
-    node.properties = { ...(node.properties || {}), ...(decoration.properties || {}) }
-    if (decoration.properties?.class)
-      addClassToHast(node, decoration.properties.class)
-    return decoration.transform?.(node, type) || node
-  }
+    node.tagName = decoration.tagName || "span";
+    node.properties = { ...(node.properties || {}), ...(decoration.properties || {}) };
+    if (decoration.properties?.class) addClassToHast(node, decoration.properties.class);
+    return decoration.transform?.(node, type) || node;
+  };
   const decorateSection = (line, start, end, decoration) => {
-    const lineNode = lines[line]
-    if (!lineNode)
-      return
-    let cursor = 0
-    let startIndex = start === 0 ? 0 : -1
-    let endIndex = end === Number.POSITIVE_INFINITY ? lineNode.children.length : -1
+    const lineNode = lines[line];
+    if (!lineNode) return;
+    let cursor = 0;
+    let startIndex = start === 0 ? 0 : -1;
+    let endIndex = end === Number.POSITIVE_INFINITY ? lineNode.children.length : -1;
     for (let index = 0; index < lineNode.children.length; index++) {
-      const length = textContentLength(lineNode.children[index])
+      const length = textContentLength(lineNode.children[index]);
       if (startIndex < 0 && cursor + length >= start)
-        startIndex = cursor + length === start ? index + 1 : index
+        startIndex = cursor + length === start ? index + 1 : index;
       if (endIndex < 0 && cursor + length >= end)
-        endIndex = cursor + length === end ? index + 1 : index
-      cursor += length
+        endIndex = cursor + length === end ? index + 1 : index;
+      cursor += length;
     }
     if (startIndex < 0 || endIndex < 0)
-      throw new ShikiError(`Failed to find decoration boundary on line ${line}`, 'ERR_USAGE')
-    const children = lineNode.children.slice(startIndex, endIndex)
+      throw new ShikiError(`Failed to find decoration boundary on line ${line}`, "ERR_USAGE");
+    const children = lineNode.children.slice(startIndex, endIndex);
     if (!decoration.alwaysWrap && children.length === lineNode.children.length) {
-      lines[line] = applyProperties(lineNode, decoration, 'line')
+      lines[line] = applyProperties(lineNode, decoration, "line");
+    } else if (!decoration.alwaysWrap && children.length === 1 && children[0].type === "element") {
+      lineNode.children[startIndex] = applyProperties(children[0], decoration, "token");
+    } else {
+      const wrapper = applyProperties(
+        {
+          type: "element",
+          tagName: decoration.tagName || "span",
+          properties: {},
+          children,
+        },
+        decoration,
+        "wrapper",
+      );
+      lineNode.children.splice(startIndex, children.length, wrapper);
     }
-    else if (!decoration.alwaysWrap && children.length === 1 && children[0].type === 'element') {
-      lineNode.children[startIndex] = applyProperties(children[0], decoration, 'token')
-    }
-    else {
-      const wrapper = applyProperties({
-        type: 'element',
-        tagName: decoration.tagName || 'span',
-        properties: {},
-        children,
-      }, decoration, 'wrapper')
-      lineNode.children.splice(startIndex, children.length, wrapper)
-    }
-  }
-  for (const decoration of [...items].sort((left, right) => right.start.offset - left.start.offset)) {
+  };
+  for (const decoration of [...items].sort(
+    (left, right) => right.start.offset - left.start.offset,
+  )) {
     if (decoration.start.line === decoration.end.line) {
-      decorateSection(decoration.start.line, decoration.start.character, decoration.end.character, decoration)
-    }
-    else {
-      decorateSection(decoration.start.line, decoration.start.character, Number.POSITIVE_INFINITY, decoration)
+      decorateSection(
+        decoration.start.line,
+        decoration.start.character,
+        decoration.end.character,
+        decoration,
+      );
+    } else {
+      decorateSection(
+        decoration.start.line,
+        decoration.start.character,
+        Number.POSITIVE_INFINITY,
+        decoration,
+      );
       for (let line = decoration.start.line + 1; line < decoration.end.line; line++)
-        lines[line] = applyProperties(lines[line], decoration, 'line')
-      decorateSection(decoration.end.line, 0, decoration.end.character, decoration)
+        lines[line] = applyProperties(lines[line], decoration, "line");
+      decorateSection(decoration.end.line, 0, decoration.end.character, decoration);
     }
   }
 }
 
 function textContentLength(node) {
-  if (node.type === 'text')
-    return node.value.length
-  return (node.children || []).reduce((total, child) => total + textContentLength(child), 0)
+  if (node.type === "text") return node.value.length;
+  return (node.children || []).reduce((total, child) => total + textContentLength(child), 0);
 }

--- a/node/oxlint.config.ts
+++ b/node/oxlint.config.ts
@@ -1,0 +1,9 @@
+import { getOxlintConfig } from "eslint-config-setup";
+import { defineConfig, type OxlintConfig } from "oxlint";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- getOxlintConfig() is not yet typed against oxlint's own OxlintConfig
+const config = getOxlintConfig({ node: true }) as OxlintConfig;
+
+config.ignorePatterns = ["**/dist/**", "coverage/**", "node_modules/**"];
+
+export default defineConfig(config);

--- a/node/package.json
+++ b/node/package.json
@@ -1,11 +1,12 @@
 {
   "name": "ferriki-workspace",
-  "type": "module",
   "version": "0.0.0",
   "private": true,
-  "packageManager": "pnpm@10.28.2",
+  "type": "module",
   "scripts": {
     "lint": "eslint . --cache",
+    "format": "oxfmt --write .",
+    "format:check": "oxfmt --check .",
     "typecheck": "tsc --noEmit",
     "build": "pnpm -C ferriki build",
     "build:native": "pnpm -C ferriki build:native",
@@ -56,6 +57,7 @@
     "fast-glob": "catalog:testing",
     "fs-extra": "catalog:testing",
     "hast-util-to-html": "catalog:inlined",
+    "oxfmt": "catalog:cli",
     "pathe": "catalog:bundling",
     "rimraf": "catalog:cli",
     "rollup": "catalog:bundling",
@@ -77,5 +79,6 @@
   "resolutions": {
     "typescript": "catalog:cli",
     "vite": "catalog:bundling"
-  }
+  },
+  "packageManager": "pnpm@10.28.2"
 }

--- a/node/platforms/darwin-arm64/package.json
+++ b/node/platforms/darwin-arm64/package.json
@@ -4,6 +4,11 @@
   "description": "Ferriki native addon for macOS arm64",
   "license": "MIT OR Apache-2.0",
   "repository": "git+https://github.com/sebastian-software/ferriki.git",
+  "files": [
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "ferriki.node"
+  ],
   "os": [
     "darwin"
   ],
@@ -11,11 +16,6 @@
     "arm64"
   ],
   "main": "ferriki.node",
-  "files": [
-    "LICENSE-APACHE",
-    "LICENSE-MIT",
-    "ferriki.node"
-  ],
   "engines": {
     "node": ">=22.13.0"
   }

--- a/node/platforms/darwin-x64/package.json
+++ b/node/platforms/darwin-x64/package.json
@@ -4,6 +4,11 @@
   "description": "Ferriki native addon for macOS x64",
   "license": "MIT OR Apache-2.0",
   "repository": "git+https://github.com/sebastian-software/ferriki.git",
+  "files": [
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "ferriki.node"
+  ],
   "os": [
     "darwin"
   ],
@@ -11,11 +16,6 @@
     "x64"
   ],
   "main": "ferriki.node",
-  "files": [
-    "LICENSE-APACHE",
-    "LICENSE-MIT",
-    "ferriki.node"
-  ],
   "engines": {
     "node": ">=22.13.0"
   }

--- a/node/platforms/linux-arm64-gnu/package.json
+++ b/node/platforms/linux-arm64-gnu/package.json
@@ -4,6 +4,11 @@
   "description": "Ferriki native addon for Linux arm64 with GNU libc",
   "license": "MIT OR Apache-2.0",
   "repository": "git+https://github.com/sebastian-software/ferriki.git",
+  "files": [
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "ferriki.node"
+  ],
   "os": [
     "linux"
   ],
@@ -14,11 +19,6 @@
     "glibc"
   ],
   "main": "ferriki.node",
-  "files": [
-    "LICENSE-APACHE",
-    "LICENSE-MIT",
-    "ferriki.node"
-  ],
   "engines": {
     "node": ">=22.13.0"
   }

--- a/node/platforms/linux-x64-gnu/package.json
+++ b/node/platforms/linux-x64-gnu/package.json
@@ -4,6 +4,11 @@
   "description": "Ferriki native addon for Linux x64 with GNU libc",
   "license": "MIT OR Apache-2.0",
   "repository": "git+https://github.com/sebastian-software/ferriki.git",
+  "files": [
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "ferriki.node"
+  ],
   "os": [
     "linux"
   ],
@@ -14,11 +19,6 @@
     "glibc"
   ],
   "main": "ferriki.node",
-  "files": [
-    "LICENSE-APACHE",
-    "LICENSE-MIT",
-    "ferriki.node"
-  ],
   "engines": {
     "node": ">=22.13.0"
   }

--- a/node/platforms/win32-x64-msvc/package.json
+++ b/node/platforms/win32-x64-msvc/package.json
@@ -4,6 +4,11 @@
   "description": "Ferriki native addon for Windows x64 with MSVC",
   "license": "MIT OR Apache-2.0",
   "repository": "git+https://github.com/sebastian-software/ferriki.git",
+  "files": [
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "ferriki.node"
+  ],
   "os": [
     "win32"
   ],
@@ -11,11 +16,6 @@
     "x64"
   ],
   "main": "ferriki.node",
-  "files": [
-    "LICENSE-APACHE",
-    "LICENSE-MIT",
-    "ferriki.node"
-  ],
   "engines": {
     "node": ">=22.13.0"
   }

--- a/node/pnpm-lock.yaml
+++ b/node/pnpm-lock.yaml
@@ -43,6 +43,9 @@ catalogs:
     eslint:
       specifier: ^9.39.2
       version: 9.39.2
+    oxfmt:
+      specifier: ^0.66.0
+      version: 0.66.0
     rimraf:
       specifier: ^6.1.2
       version: 6.1.3
@@ -236,6 +239,9 @@ importers:
       hast-util-to-html:
         specifier: catalog:inlined
         version: 9.0.5
+      oxfmt:
+        specifier: catalog:cli
+        version: 0.66.0
       pathe:
         specifier: catalog:bundling
         version: 2.0.3
@@ -1029,6 +1035,128 @@ packages:
 
   '@oxc-project/types@0.115.0':
     resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+
+  '@oxfmt/binding-android-arm-eabi@0.66.0':
+    resolution: {integrity: sha512-2Me9eoptv6ERdEuI2P8AOlYdHHraXebJaM6SC0kc2Dfb+mLrep2db+fedBPKaYn673h/vBgvP4tkOdAbaudX6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.66.0':
+    resolution: {integrity: sha512-u7O+bSSF0HGsDKkQQxBqvLGVepu93RA+JKu+ONqvfh4sCnCEbj31wZj4iG5gk3XfRwrmYj0/8catkO2LcblQKQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.66.0':
+    resolution: {integrity: sha512-/ikyMIVjX/sdo7KtjxoEsSUosfPzveVhT9RWMx9yGqFDKFJ89JAEKuEeLBmurDjrkb4w8tOnAdSO3SBaplY3bw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.66.0':
+    resolution: {integrity: sha512-q5xUsKeFqawa9NXa6ZGXWimFV19m8MogKPdTaSVDAAk2EQKBmBZRDeluwcl1p8ty/OFc9s9888OKEh3xfPVH0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.66.0':
+    resolution: {integrity: sha512-CR+x4VzMY0pRXLK/xFQ/RzsSFkP5t2Z2mef0QY6OP/rTRcMUoMLCOM62/3Fp/t0K+UDoBKxvMyeb6D0zPMjleA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.66.0':
+    resolution: {integrity: sha512-ZEYmO/LbH9tTQCADILHGZE4GeOXOAj2VzedHkASNwjmwlwtutJCLpCJbIs37wRGTFgWRoEcD72jpMX+IBJUGjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.66.0':
+    resolution: {integrity: sha512-hNtR9/oU0CeTkq7JnRkmBQwqe17v2ZaAMLC4VcN7IIOWeRyWDk0knSPWS9iiLmtbZ2RRBBtsG01jQgkZmKCJeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.66.0':
+    resolution: {integrity: sha512-uwOVQ8i6I1LT/+eDzfsgrrcZp8Fn6NPVUPn8fF5gdFGekFf0PddF+LEuwsD0/pbNUcKZhDj2rQ5UpITh9gF4iQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.66.0':
+    resolution: {integrity: sha512-tTkF2Dmx4nGAjmBlZb+UtTGqR/EK4ZrW9qBfzte07a9XWqzoGGKzpFFlyNDhQe+Uwql94+ReCTeNbhOXscw1Dg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.66.0':
+    resolution: {integrity: sha512-F3cKHUav4yXOHn6GFnwpBhSYsJOYKKf9eqO/9jlEuqPxNw9zb98E9ZFct79gcg8pibUGkbveEu9WDlmXJpDzKw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.66.0':
+    resolution: {integrity: sha512-K5fDaNZfDyQMYA/3qL21bqyN0X9T15LLwwbFPt2aHc94+ZG7bh0vZEsy2y7NlRnjjHFSwN+Hzg6ldJtbOriH4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.66.0':
+    resolution: {integrity: sha512-44Yc+I+qOmTElRcEhm5hUKIUJEQIOugymz4ua4tB0Wox7tGAfIbjzmXz/HDAtw1Ij6gmBwZlzh4hc9679RhWeA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.66.0':
+    resolution: {integrity: sha512-1e29Eg9hEj2kRBB19M0seIehPbbXHCk35GvImjDvb79rjjYjXCRmtbUNHJcgoktZAMIzXrTbxDBKmTc1V4bg3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.66.0':
+    resolution: {integrity: sha512-vODY1UQo10gngn0+D4xHKU84F1Twm1LqrzV4SqPXvmQKSd87paehvZ6jqA5wKs6XQrlWul9clYMDVHcoW9CPMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.66.0':
+    resolution: {integrity: sha512-YDzXx2JsT4+HL4MdkVrYjO55NS5lUKNm8rLC4ZPou8+seu0v0jhecSh+ufoO6+xEa8gccEezMlI2WHJi4ApUgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.66.0':
+    resolution: {integrity: sha512-mJjUYd8lj0+j4JkYyEM+5qKBf1Rnrpgjn/SVYKJhicVDqLz566ooa7Fs8zflPqt+dnZDV7X054rVIQX6ZcQNlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.66.0':
+    resolution: {integrity: sha512-soV+0vESv7e5ntCHWC61x4gg8OSak6IHHnWsZmHrJFlvMj2AK+kmldErCNkVkrvc1Ts2/++rJXn+IuAb2WMXhw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.66.0':
+    resolution: {integrity: sha512-YCPi23uRIEYuIKTZohAkKbPFpujQ5QBuUM5iDv+UqbCmTPAkaFsxjsSuB8xlBpRT0G7eP/4HMF+cPDSqHtOD9A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.66.0':
+    resolution: {integrity: sha512-bwTQcv/JVRPkOqQtMF0X7vpvpncDQiBcXHxZ9S2hR12Hlo8bvBdUR5x5XnxzDZ3kM0qoZw1rv7KaD66Ly+pFWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
@@ -2724,6 +2852,19 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  oxfmt@0.66.0:
+    resolution: {integrity: sha512-FfvqR8RFtV6JJpRrpkfqyVCQ7HDvZ/VriWFx7veftCgL1B5ZO9qNr+1rvPieycMQnNfVG0PWyJQiy7p0hq1I5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -3081,6 +3222,10 @@ packages:
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -3804,6 +3949,63 @@ snapshots:
   '@oxc-project/types@0.112.0': {}
 
   '@oxc-project/types@0.115.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.66.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.66.0':
+    optional: true
 
   '@pkgr/core@0.2.9': {}
 
@@ -5706,6 +5908,30 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  oxfmt@0.66.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.66.0
+      '@oxfmt/binding-android-arm64': 0.66.0
+      '@oxfmt/binding-darwin-arm64': 0.66.0
+      '@oxfmt/binding-darwin-x64': 0.66.0
+      '@oxfmt/binding-freebsd-x64': 0.66.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.66.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.66.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.66.0
+      '@oxfmt/binding-linux-arm64-musl': 0.66.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.66.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.66.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.66.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.66.0
+      '@oxfmt/binding-linux-x64-gnu': 0.66.0
+      '@oxfmt/binding-linux-x64-musl': 0.66.0
+      '@oxfmt/binding-openharmony-arm64': 0.66.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.66.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.66.0
+      '@oxfmt/binding-win32-x64-msvc': 0.66.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -6097,6 +6323,8 @@ snapshots:
       picomatch: 4.0.3
 
   tinypool@1.1.1: {}
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@2.0.0: {}
 

--- a/node/pnpm-workspace.yaml
+++ b/node/pnpm-workspace.yaml
@@ -1,4 +1,10 @@
 catalogMode: prefer
+# The organization's own packages are exempt from pnpm's release cooldown, so
+# an internal release installs immediately instead of after a day
+# (@sebastian-software/standards, changes/0006).
+minimumReleaseAgeExclude:
+  - "@sebastian-gmbh/*"
+  - "@sebastian-software/*"
 # The five native sidecars are workspace packages that carry a plain version
 # range, not `workspace:*`, because they are published with `npm publish`.
 # pnpm 10 does not link those by default, and without this it silently drops
@@ -13,9 +19,9 @@ packages:
   - compat/upstream/shiki/packages/*
 catalogs:
   bundling:
-    '@rollup/plugin-commonjs': ^29.0.0
-    '@rollup/plugin-json': ^6.1.0
-    '@rollup/plugin-node-resolve': ^16.0.3
+    "@rollup/plugin-commonjs": ^29.0.0
+    "@rollup/plugin-json": ^6.1.0
+    "@rollup/plugin-node-resolve": ^16.0.3
     pathe: ^2.0.3
     rollup: ^4.57.0
     rollup-plugin-copy: ^3.5.0
@@ -25,8 +31,9 @@ catalogs:
     vite: ^7.3.1
     vite-tsconfig-paths: ^6.0.5
   cli:
-    '@antfu/eslint-config': ^7.2.0
+    "@antfu/eslint-config": ^7.2.0
     eslint: ^9.39.2
+    oxfmt: ^0.66.0
     rimraf: ^6.1.2
     tsx: ^4.21.0
     typescript: ^5.9.3
@@ -34,8 +41,8 @@ catalogs:
     floating-vue: ^5.2.2
     vue: ^3.5.27
   icons:
-    '@iconify-json/carbon': ^1.2.18
-    '@iconify-json/codicon': ^1.2.41
+    "@iconify-json/carbon": ^1.2.18
+    "@iconify-json/codicon": ^1.2.41
   inlined:
     ansi-sequence-parser: ^1.1.3
     hast-util-from-html: ^2.0.3
@@ -62,19 +69,19 @@ catalogs:
     unified: ^11.0.5
     unist-util-visit: ^5.1.0
   prod:
-    '@shikijs/vscode-textmate': ^10.0.2
+    "@shikijs/vscode-textmate": ^10.0.2
     oniguruma-to-es: ^4.3.4
   testing:
     fast-glob: ^3.3.3
     fs-extra: ^11.3.3
     vitest: ^3.2.4
   types:
-    '@types/fs-extra': ^11.0.4
-    '@types/hast': ^3.0.4
-    '@types/markdown-it': ^14.1.2
+    "@types/fs-extra": ^11.0.4
+    "@types/hast": ^3.0.4
+    "@types/markdown-it": ^14.1.2
     # Pinned to the exact version resolved by the mirrored shiki release tag
     # (v4.4.3); the twoslash compat snapshots embed @types/node JSDoc hovers.
-    '@types/node': 25.3.3
+    "@types/node": 25.3.3
 onlyBuiltDependencies:
   - esbuild
   - sharp

--- a/node/scripts/check-docs-contract.mjs
+++ b/node/scripts/check-docs-contract.mjs
@@ -1,72 +1,90 @@
-import assert from 'node:assert/strict'
-import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const nodeRoot = join(fileURLToPath(new URL('.', import.meta.url)), '..')
-const repoRoot = join(nodeRoot, '..')
-const declarationPath = join(nodeRoot, 'ferriki', 'src', 'api.d.mts')
-const apiPath = join(repoRoot, 'docs', 'ferriki-api.md')
-const migrationPath = join(repoRoot, 'docs', 'migrations', 'shiki-to-ferriki.md')
-const compatibilityPath = join(repoRoot, 'docs', 'compatibility.md')
-const troubleshootingPath = join(repoRoot, 'docs', 'troubleshooting.md')
-const rootReadmePath = join(repoRoot, 'README.md')
-const packageReadmePath = join(nodeRoot, 'ferriki', 'README.md')
-const sourcePath = join(nodeRoot, 'compat', 'upstream', 'shiki', '.source.json')
+const nodeRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const repoRoot = join(nodeRoot, "..");
+const declarationPath = join(nodeRoot, "ferriki", "src", "api.d.mts");
+const apiPath = join(repoRoot, "docs", "ferriki-api.md");
+const migrationPath = join(repoRoot, "docs", "migrations", "shiki-to-ferriki.md");
+const compatibilityPath = join(repoRoot, "docs", "compatibility.md");
+const troubleshootingPath = join(repoRoot, "docs", "troubleshooting.md");
+const rootReadmePath = join(repoRoot, "README.md");
+const packageReadmePath = join(nodeRoot, "ferriki", "README.md");
+const sourcePath = join(nodeRoot, "compat", "upstream", "shiki", ".source.json");
 
-const declarations = await readFile(declarationPath, 'utf8')
-const api = await readFile(apiPath, 'utf8')
-const migration = await readFile(migrationPath, 'utf8')
-const compatibility = await readFile(compatibilityPath, 'utf8')
-const troubleshooting = await readFile(troubleshootingPath, 'utf8')
-const rootReadme = await readFile(rootReadmePath, 'utf8')
-const packageReadme = await readFile(packageReadmePath, 'utf8')
-const source = JSON.parse(await readFile(sourcePath, 'utf8'))
+const declarations = await readFile(declarationPath, "utf8");
+const api = await readFile(apiPath, "utf8");
+const migration = await readFile(migrationPath, "utf8");
+const compatibility = await readFile(compatibilityPath, "utf8");
+const troubleshooting = await readFile(troubleshootingPath, "utf8");
+const rootReadme = await readFile(rootReadmePath, "utf8");
+const packageReadme = await readFile(packageReadmePath, "utf8");
+const source = JSON.parse(await readFile(sourcePath, "utf8"));
 
-const exportedNames = [...declarations.matchAll(/^export (?:declare )?(?:function|class|const|interface|type)\s+(\w+)/gm)]
-  .map(match => match[1])
+const exportedNames = [
+  ...declarations.matchAll(
+    /^export (?:declare )?(?:function|class|const|interface|type)\s+(\w+)/gm,
+  ),
+].map((match) => match[1]);
 
 for (const name of exportedNames)
-  assert(api.includes(name), `docs/ferriki-api.md is missing declared export: ${name}`)
+  assert(api.includes(name), `docs/ferriki-api.md is missing declared export: ${name}`);
 
-assert.match(source.ref, /^v\d+\.\d+\.\d+$/, 'the pinned Shiki source must record an exact release tag')
-assert(migration.includes(`Shiki **${source.ref}**`), 'migration guide must name the exact Shiki baseline')
-assert(compatibility.includes(`Shiki ${source.ref}`), 'compatibility guide must name the exact Shiki baseline')
-assert(rootReadme.includes('docs/ferriki-api.md'), 'root README must link the API reference')
+assert.match(
+  source.ref,
+  /^v\d+\.\d+\.\d+$/,
+  "the pinned Shiki source must record an exact release tag",
+);
+assert(
+  migration.includes(`Shiki **${source.ref}**`),
+  "migration guide must name the exact Shiki baseline",
+);
+assert(
+  compatibility.includes(`Shiki ${source.ref}`),
+  "compatibility guide must name the exact Shiki baseline",
+);
+assert(rootReadme.includes("docs/ferriki-api.md"), "root README must link the API reference");
 const packageReadmeLinks = [
-  'docs/ferriki-api.md',
-  'docs/migrations/shiki-to-ferriki.md',
-  'docs/compatibility.md',
-  'docs/troubleshooting.md',
-]
+  "docs/ferriki-api.md",
+  "docs/migrations/shiki-to-ferriki.md",
+  "docs/compatibility.md",
+  "docs/troubleshooting.md",
+];
 for (const target of packageReadmeLinks) {
   assert(
     packageReadme.includes(`https://github.com/sebastian-software/ferriki/blob/main/${target}`),
     `package README must link ${target} absolutely, because npmjs.com renders it outside the repository tree`,
-  )
+  );
 }
 assert.doesNotMatch(
   packageReadme,
   /\]\(\.\.\//,
-  'package README must not use repository-relative links',
-)
+  "package README must not use repository-relative links",
+);
 
 // The block itself is generated from the family registry and verified against
 // it by `node scripts/sync-readme-family.mjs --check`; this only holds the
 // markers in place, so a README cannot quietly lose the family block offline.
 const familyBlockReadmes = [
-  ['README.md', rootReadme],
-  ['node/ferriki/README.md', packageReadme],
-]
+  ["README.md", rootReadme],
+  ["node/ferriki/README.md", packageReadme],
+];
 for (const [label, content] of familyBlockReadmes) {
-  for (const marker of ['<!-- ferramenta-family:start -->', '<!-- ferramenta-family:end -->']) {
+  for (const marker of ["<!-- ferramenta-family:start -->", "<!-- ferramenta-family:end -->"]) {
     assert(
       content.includes(marker),
       `${label} must keep ${marker}; regenerate with \`node scripts/sync-readme-family.mjs\``,
-    )
+    );
   }
 }
 
-assert(troubleshooting.includes('No native binary for <platform>-<arch>'), 'troubleshooting must start from the actual loader error')
+assert(
+  troubleshooting.includes("No native binary for <platform>-<arch>"),
+  "troubleshooting must start from the actual loader error",
+);
 
-console.log(`Ferriki docs contract verified (${exportedNames.length} declared exports, ${source.ref} baseline)`)
+console.log(
+  `Ferriki docs contract verified (${exportedNames.length} declared exports, ${source.ref} baseline)`,
+);

--- a/node/scripts/check-docs-drift.mjs
+++ b/node/scripts/check-docs-drift.mjs
@@ -1,56 +1,62 @@
-import assert from 'node:assert/strict'
-import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
-import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-export const CLAUDE_POINTER = '@AGENTS.md'
+export const CLAUDE_POINTER = "@AGENTS.md";
 
 // Phrases that described states the repository has since left behind.
 export const STALE_GUIDANCE = [
-  ['AGENTS.md', [
-    'npm package is a placeholder',
-    'Compat lanes are suspended',
-    'currently a placeholder exposing only',
-    'FERRIKI_BACKEND',
-  ]],
-  ['plans/ferriki-remaining-work.md', [
-    'the backend switch is `FERRIKI_BACKEND`',
-    'still back the JS engine path',
-    'currently a placeholder exposing only',
-  ]],
-  ['plans/ferriki-asset-pipeline-implementation-plan.md', [
-    'Phase 5 (removing the transitional',
-    'reduce or remove `dist/chunks/*.mjs` once',
-  ]],
-]
+  [
+    "AGENTS.md",
+    [
+      "npm package is a placeholder",
+      "Compat lanes are suspended",
+      "currently a placeholder exposing only",
+      "FERRIKI_BACKEND",
+    ],
+  ],
+  [
+    "plans/ferriki-remaining-work.md",
+    [
+      "the backend switch is `FERRIKI_BACKEND`",
+      "still back the JS engine path",
+      "currently a placeholder exposing only",
+    ],
+  ],
+  [
+    "plans/ferriki-asset-pipeline-implementation-plan.md",
+    ["Phase 5 (removing the transitional", "reduce or remove `dist/chunks/*.mjs` once"],
+  ],
+];
 
 // Files that state the *current* Shiki baseline. Dated records under `plans/`
 // and `adr/` keep the version that was pinned when they were written.
 export const SHIKI_BASELINE_DOCS = [
-  'README.md',
-  'CONTRIBUTING.md',
-  'docs/compatibility.md',
-  'docs/migrations/shiki-to-ferriki.md',
-  'node/ferriki/README.md',
-]
+  "README.md",
+  "CONTRIBUTING.md",
+  "docs/compatibility.md",
+  "docs/migrations/shiki-to-ferriki.md",
+  "node/ferriki/README.md",
+];
 
 // Files that state the Node floor declared by `engines.node`.
 export const NODE_FLOOR_DOCS = [
-  'README.md',
-  'CONTRIBUTING.md',
-  'AGENTS.md',
-  'docs/compatibility.md',
-  'docs/ferriki-api.md',
-  'docs/ferriki-1.0-api-contract.md',
-  'node/ferriki/README.md',
-]
+  "README.md",
+  "CONTRIBUTING.md",
+  "AGENTS.md",
+  "docs/compatibility.md",
+  "docs/ferriki-api.md",
+  "docs/ferriki-1.0-api-contract.md",
+  "node/ferriki/README.md",
+];
 
-export const SHIKI_SOURCE = 'node/compat/upstream/shiki/.source.json'
-export const FERRIKI_PACKAGE = 'node/ferriki/package.json'
+export const SHIKI_SOURCE = "node/compat/upstream/shiki/.source.json";
+export const FERRIKI_PACKAGE = "node/ferriki/package.json";
 
-const SHIKI_VERSION_PATTERN = /Shiki \*{0,2}(v\d+\.\d+\.\d+)/g
-const NODE_VERSION_PATTERN = /Node(?:\.js)?\s*(?:>=\s*)?v?(\d+(?:\.\d+)*)/g
+const SHIKI_VERSION_PATTERN = /Shiki \*{0,2}(v\d+\.\d+\.\d+)/g;
+const NODE_VERSION_PATTERN = /Node(?:\.js)?\s*(?:>=\s*)?v?(\d+(?:\.\d+)*)/g;
 
 /**
  * Checks the contributor documents under `root` for stale guidance and for
@@ -58,70 +64,72 @@ const NODE_VERSION_PATTERN = /Node(?:\.js)?\s*(?:>=\s*)?v?(\d+(?:\.\d+)*)/g
  * Throws an AssertionError on the first drift found.
  */
 export async function checkDocsDrift(root) {
-  const read = relative => readFile(join(root, relative), 'utf8')
+  const read = (relative) => readFile(join(root, relative), "utf8");
 
-  const claude = await read('CLAUDE.md')
+  const claude = await read("CLAUDE.md");
   assert.equal(
     claude.trim(),
     CLAUDE_POINTER,
     `CLAUDE.md must be exactly the pointer line \`${CLAUDE_POINTER}\`; agent guidance belongs in AGENTS.md, which this script checks for stale phrases.`,
-  )
+  );
 
   for (const [relative, stalePhrases] of STALE_GUIDANCE) {
-    const source = await read(relative)
+    const source = await read(relative);
     for (const phrase of stalePhrases)
-      assert(!source.includes(phrase), `${relative} contains stale guidance: ${phrase}`)
+      assert(!source.includes(phrase), `${relative} contains stale guidance: ${phrase}`);
   }
 
   // Positive contracts: prose facts that have exactly one machine-readable source.
-  const shikiSource = JSON.parse(await read(SHIKI_SOURCE))
+  const shikiSource = JSON.parse(await read(SHIKI_SOURCE));
   assert.match(
     shikiSource.ref,
     /^v\d+\.\d+\.\d+$/,
     `${SHIKI_SOURCE} must pin an exact Shiki release tag`,
-  )
+  );
 
   for (const relative of SHIKI_BASELINE_DOCS) {
-    const source = await read(relative)
-    const mentioned = [...source.matchAll(SHIKI_VERSION_PATTERN)].map(match => match[1])
+    const source = await read(relative);
+    const mentioned = [...source.matchAll(SHIKI_VERSION_PATTERN)].map((match) => match[1]);
     assert(
       mentioned.length > 0,
       `${relative} must name the pinned Shiki baseline (${shikiSource.ref})`,
-    )
-    const stale = [...new Set(mentioned)].filter(version => version !== shikiSource.ref)
+    );
+    const stale = [...new Set(mentioned)].filter((version) => version !== shikiSource.ref);
     assert(
       stale.length === 0,
-      `${relative} names a stale Shiki baseline (${stale.join(', ')}); the mirror pins ${shikiSource.ref}`,
-    )
+      `${relative} names a stale Shiki baseline (${stale.join(", ")}); the mirror pins ${shikiSource.ref}`,
+    );
   }
 
-  const ferrikiPackage = JSON.parse(await read(FERRIKI_PACKAGE))
-  const nodeFloor = String(ferrikiPackage.engines?.node ?? '').replace(/^\D*/, '')
+  const ferrikiPackage = JSON.parse(await read(FERRIKI_PACKAGE));
+  const nodeFloor = String(ferrikiPackage.engines?.node ?? "").replace(/^\D*/, "");
   assert.match(
     nodeFloor,
     /^\d+\.\d+\.\d+$/,
     `${FERRIKI_PACKAGE} must declare an exact Node floor in \`engines.node\``,
-  )
+  );
 
   for (const relative of NODE_FLOOR_DOCS) {
-    const source = await read(relative)
-    const mentioned = [...source.matchAll(NODE_VERSION_PATTERN)].map(match => match[1])
+    const source = await read(relative);
+    const mentioned = [...source.matchAll(NODE_VERSION_PATTERN)].map((match) => match[1]);
     assert(
       mentioned.includes(nodeFloor),
       `${relative} must state the Node floor ${nodeFloor} declared by ${FERRIKI_PACKAGE}`,
-    )
-    const stale = [...new Set(mentioned)].filter(version => version !== nodeFloor)
+    );
+    const stale = [...new Set(mentioned)].filter((version) => version !== nodeFloor);
     assert(
       stale.length === 0,
-      `${relative} states a Node version other than the declared floor ${nodeFloor}: ${stale.join(', ')}`,
-    )
+      `${relative} states a Node version other than the declared floor ${nodeFloor}: ${stale.join(", ")}`,
+    );
   }
 
-  return { shikiRef: shikiSource.ref, nodeFloor }
+  return { shikiRef: shikiSource.ref, nodeFloor };
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const root = join(fileURLToPath(new URL('.', import.meta.url)), '../..')
-  const { shikiRef, nodeFloor } = await checkDocsDrift(root)
-  console.log(`Ferriki contributor-doc guidance is current (Shiki ${shikiRef} baseline, Node >= ${nodeFloor})`)
+  const root = join(fileURLToPath(new URL(".", import.meta.url)), "../..");
+  const { shikiRef, nodeFloor } = await checkDocsDrift(root);
+  console.log(
+    `Ferriki contributor-doc guidance is current (Shiki ${shikiRef} baseline, Node >= ${nodeFloor})`,
+  );
 }

--- a/node/scripts/check-ferriki-ansi.mjs
+++ b/node/scripts/check-ferriki-ansi.mjs
@@ -1,23 +1,24 @@
-import assert from 'node:assert/strict'
+import assert from "node:assert/strict";
 
-import { createHighlighter, ShikiError } from '../ferriki/index.mjs'
+import { createHighlighter, ShikiError } from "../ferriki/index.mjs";
 
-const highlighter = await createHighlighter({ themes: ['nord'] })
-const ansi = `${String.fromCharCode(27)}[31mred${String.fromCharCode(27)}[0m`
+const highlighter = await createHighlighter({ themes: ["nord"] });
+const ansi = `${String.fromCharCode(27)}[31mred${String.fromCharCode(27)}[0m`;
 try {
   for (const render of [
-    () => highlighter.codeToHtml(ansi, { lang: 'ansi', theme: 'nord' }),
-    () => highlighter.codeToHast(ansi, { lang: 'ansi', theme: 'nord' }),
-    () => highlighter.codeToTokens(ansi, { lang: 'ansi', theme: 'nord' }),
+    () => highlighter.codeToHtml(ansi, { lang: "ansi", theme: "nord" }),
+    () => highlighter.codeToHast(ansi, { lang: "ansi", theme: "nord" }),
+    () => highlighter.codeToTokens(ansi, { lang: "ansi", theme: "nord" }),
   ]) {
     assert.throws(
       render,
-      error => error instanceof ShikiError && /ANSI control sequences are not supported/.test(error.message),
-    )
+      (error) =>
+        error instanceof ShikiError &&
+        /ANSI control sequences are not supported/.test(error.message),
+    );
   }
-}
-finally {
-  highlighter.dispose()
+} finally {
+  highlighter.dispose();
 }
 
-console.log('Ferriki ANSI contract verified')
+console.log("Ferriki ANSI contract verified");

--- a/node/scripts/check-ferriki-api-contract.mjs
+++ b/node/scripts/check-ferriki-api-contract.mjs
@@ -1,5 +1,5 @@
-import assert from 'node:assert/strict'
-import { readFile } from 'node:fs/promises'
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 
 import {
   bundledLanguages,
@@ -9,68 +9,70 @@ import {
   createCssVariablesTheme,
   createHighlighter,
   ShikiError,
-} from '../ferriki/index.mjs'
+} from "../ferriki/index.mjs";
 
-const contract = await readFile(new URL('../../docs/ferriki-1.0-api-contract.md', import.meta.url), 'utf8')
+const contract = await readFile(
+  new URL("../../docs/ferriki-1.0-api-contract.md", import.meta.url),
+  "utf8",
+);
 for (const row of [
-  '| `bundledLanguages` / `bundledThemes` | Stable |',
-  '| `themes` | Stable |',
-  '| `defaultColor` | Stable |',
-  '| `transformers` | Stable |',
-  '| `decorations` | Stable |',
-  '| ANSI input | Removed |',
-  '| `theme: \'none\'` | Stable |',
-  '- A highlighter handle owns its native state and must be disposable.',
+  "| `bundledLanguages` / `bundledThemes` | Stable |",
+  "| `themes` | Stable |",
+  "| `defaultColor` | Stable |",
+  "| `transformers` | Stable |",
+  "| `decorations` | Stable |",
+  "| ANSI input | Removed |",
+  "| `theme: 'none'` | Stable |",
+  "- A highlighter handle owns its native state and must be disposable.",
 ]) {
-  assert(contract.includes(row), `API contract is missing the required row: ${row}`)
+  assert(contract.includes(row), `API contract is missing the required row: ${row}`);
 }
 
-assert(Object.isFrozen(bundledLanguages))
-assert(Object.isFrozen(bundledThemes))
-assert(Object.isFrozen(bundledLanguagesAlias))
-assert(Object.hasOwn(bundledLanguages, 'typescript'))
-assert(Object.hasOwn(bundledLanguagesAlias, 'ts'))
-assert(Object.hasOwn(bundledThemes, 'nord'))
+assert(Object.isFrozen(bundledLanguages));
+assert(Object.isFrozen(bundledThemes));
+assert(Object.isFrozen(bundledLanguagesAlias));
+assert(Object.hasOwn(bundledLanguages, "typescript"));
+assert(Object.hasOwn(bundledLanguagesAlias, "ts"));
+assert(Object.hasOwn(bundledThemes, "nord"));
 
 const cssTheme = createCssVariablesTheme({
-  name: 'contract-css',
-  type: 'light',
-  variableDefaults: { foreground: '#111111', background: '#ffffff' },
-})
+  name: "contract-css",
+  type: "light",
+  variableDefaults: { foreground: "#111111", background: "#ffffff" },
+});
 assert.deepEqual(cssTheme, {
-  name: 'contract-css',
-  type: 'light',
-  fg: '#111111',
-  bg: '#ffffff',
+  name: "contract-css",
+  type: "light",
+  fg: "#111111",
+  bg: "#ffffff",
   settings: [],
-})
+});
 
-const highlighter = await createHighlighter({ themes: ['nord'] })
+const highlighter = await createHighlighter({ themes: ["nord"] });
 try {
-  assert.equal(highlighter.getLoadedLanguages().includes('typescript'), false)
-  await highlighter.loadLanguage(bundledLanguages.typescript)
-  assert(highlighter.getLoadedLanguages().includes('typescript'))
+  assert.equal(highlighter.getLoadedLanguages().includes("typescript"), false);
+  await highlighter.loadLanguage(bundledLanguages.typescript);
+  assert(highlighter.getLoadedLanguages().includes("typescript"));
 
-  const single = highlighter.codeToHtml('const answer = 42', { lang: 'typescript', theme: 'nord' })
-  assert(single.includes('const'))
-  const dual = highlighter.codeToHtml('const answer = 42', {
-    lang: 'typescript',
-    themes: { light: 'vitesse-light', dark: 'nord' },
+  const single = highlighter.codeToHtml("const answer = 42", { lang: "typescript", theme: "nord" });
+  assert(single.includes("const"));
+  const dual = highlighter.codeToHtml("const answer = 42", {
+    lang: "typescript",
+    themes: { light: "vitesse-light", dark: "nord" },
     defaultColor: false,
-  })
-  assert.match(dual, /--shiki-light:/)
-  assert.match(dual, /--shiki-dark:/)
+  });
+  assert.match(dual, /--shiki-light:/);
+  assert.match(dual, /--shiki-dark:/);
 
-  const shorthand = await codeToHtml('const answer = 42', { lang: 'typescript', theme: 'nord' })
-  assert(shorthand.includes('const'))
-}
-finally {
-  highlighter.dispose()
+  const shorthand = await codeToHtml("const answer = 42", { lang: "typescript", theme: "nord" });
+  assert(shorthand.includes("const"));
+} finally {
+  highlighter.dispose();
 }
 
 assert.throws(
-  () => highlighter.loadThemeSync('nord'),
-  error => error instanceof ShikiError && error.code === 'ERR_USAGE',
-)
+  () => highlighter.loadThemeSync("nord"),
+  (error) => error instanceof ShikiError && error.code === "ERR_USAGE",
+);
 
-console.log('Ferriki 1.0 API contract verified')
+console.log("Ferriki 1.0 API contract verified");

--- a/node/scripts/check-ferriki-catalog.mjs
+++ b/node/scripts/check-ferriki-catalog.mjs
@@ -1,93 +1,98 @@
-import assert from 'node:assert/strict'
-import { constants } from 'node:fs'
-import { access, readdir } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { constants } from "node:fs";
+import { access, readdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-import { languageCatalog, themeCatalog } from '../ferriki/assets/shiki/catalog.mjs'
+import { languageCatalog, themeCatalog } from "../ferriki/assets/shiki/catalog.mjs";
 import {
   bundledLanguages,
   bundledLanguagesAlias,
   bundledThemes,
   createHighlighter,
-} from '../ferriki/index.mjs'
+} from "../ferriki/index.mjs";
 
-const packageDir = dirname(dirname(fileURLToPath(import.meta.url)))
-const assetRoot = join(packageDir, 'ferriki', 'assets', 'shiki')
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const assetRoot = join(packageDir, "ferriki", "assets", "shiki");
 
-assert(Object.isFrozen(bundledLanguages), 'bundledLanguages must be immutable')
-assert(Object.isFrozen(bundledThemes), 'bundledThemes must be immutable')
-assert(Object.isFrozen(bundledLanguagesAlias), 'bundledLanguagesAlias must be immutable')
-assert(languageCatalog.length > 0, 'language catalog is empty')
-assert(themeCatalog.length > 0, 'theme catalog is empty')
+assert(Object.isFrozen(bundledLanguages), "bundledLanguages must be immutable");
+assert(Object.isFrozen(bundledThemes), "bundledThemes must be immutable");
+assert(Object.isFrozen(bundledLanguagesAlias), "bundledLanguagesAlias must be immutable");
+assert(languageCatalog.length > 0, "language catalog is empty");
+assert(themeCatalog.length > 0, "theme catalog is empty");
 
-const languageIds = new Set(languageCatalog.map(entry => entry.id))
-const languageKeys = new Set(languageCatalog.flatMap(entry => [entry.id, ...entry.aliases]))
-assert.deepEqual(Object.keys(bundledLanguages), [...languageKeys].sort(compareIds))
-assert.deepEqual(Object.keys(bundledLanguagesAlias), languageCatalog
-  .flatMap(entry => entry.aliases)
-  .sort(compareIds))
+const languageIds = new Set(languageCatalog.map((entry) => entry.id));
+const languageKeys = new Set(languageCatalog.flatMap((entry) => [entry.id, ...entry.aliases]));
+assert.deepEqual(Object.keys(bundledLanguages), [...languageKeys].sort(compareIds));
+assert.deepEqual(
+  Object.keys(bundledLanguagesAlias),
+  languageCatalog.flatMap((entry) => entry.aliases).sort(compareIds),
+);
 
 for (const entry of languageCatalog) {
-  await assertAsset(join(assetRoot, 'languages', entry.assetFile))
-  const registration = (await bundledLanguages[entry.id]())[0]
-  assert.equal(registration.name, entry.id)
-  assert.equal(registration.scopeName, entry.scopeName)
-  assert.deepEqual(registration.aliases, entry.aliases)
+  await assertAsset(join(assetRoot, "languages", entry.assetFile));
+  const registration = (await bundledLanguages[entry.id]())[0];
+  assert.equal(registration.name, entry.id);
+  assert.equal(registration.scopeName, entry.scopeName);
+  assert.deepEqual(registration.aliases, entry.aliases);
   for (const alias of entry.aliases) {
-    assert.equal(bundledLanguagesAlias[alias], entry.id)
-    assert.equal((await bundledLanguages[alias]())[0].name, entry.id)
+    assert.equal(bundledLanguagesAlias[alias], entry.id);
+    assert.equal((await bundledLanguages[alias]())[0].name, entry.id);
   }
 }
 
 for (const entry of themeCatalog) {
-  await assertAsset(join(assetRoot, 'themes', entry.assetFile))
-  const registration = await bundledThemes[entry.id]()
-  assert.equal(registration.name, entry.id)
-  assert.equal(registration.type, entry.themeType || undefined)
+  await assertAsset(join(assetRoot, "themes", entry.assetFile));
+  const registration = await bundledThemes[entry.id]();
+  assert.equal(registration.name, entry.id);
+  assert.equal(registration.type, entry.themeType || undefined);
 }
 
-assert.equal(Object.hasOwn(bundledLanguages, 'not-a-real-language'), false)
-assert.equal(Object.hasOwn(bundledThemes, 'not-a-real-theme'), false)
-assert.equal(Object.hasOwn(bundledLanguagesAlias, 'not-a-real-alias'), false)
-assert(languageIds.has('typescript'), 'typescript must be enumerable')
-assert(languageIds.has('vue'), 'vue must be enumerable')
-assert(Object.hasOwn(bundledLanguagesAlias, 'ts'), 'typescript alias must be enumerable')
-assert(Object.hasOwn(bundledThemes, 'nord'), 'nord must be enumerable')
+assert.equal(Object.hasOwn(bundledLanguages, "not-a-real-language"), false);
+assert.equal(Object.hasOwn(bundledThemes, "not-a-real-theme"), false);
+assert.equal(Object.hasOwn(bundledLanguagesAlias, "not-a-real-alias"), false);
+assert(languageIds.has("typescript"), "typescript must be enumerable");
+assert(languageIds.has("vue"), "vue must be enumerable");
+assert(Object.hasOwn(bundledLanguagesAlias, "ts"), "typescript alias must be enumerable");
+assert(Object.hasOwn(bundledThemes, "nord"), "nord must be enumerable");
 
 const highlighter = await createHighlighter({
   langs: [bundledLanguages.typescript(), bundledLanguages.vue()],
   themes: [bundledThemes.nord()],
-})
+});
 try {
-  const typescript = highlighter.codeToHtml('const answer: number = 42', {
-    lang: 'typescript',
-    theme: 'nord',
-  })
-  assert.match(typescript, /const/)
+  const typescript = highlighter.codeToHtml("const answer: number = 42", {
+    lang: "typescript",
+    theme: "nord",
+  });
+  assert.match(typescript, /const/);
   const vue = highlighter.codeToHtml('<script setup lang="ts">const answer = 42</script>', {
-    lang: 'vue',
-    theme: 'nord',
-  })
-  assert.match(vue, /script/)
-}
-finally {
-  highlighter.dispose()
+    lang: "vue",
+    theme: "nord",
+  });
+  assert.match(vue, /script/);
+} finally {
+  highlighter.dispose();
 }
 
 const [languageFiles, themeFiles] = await Promise.all([
-  readdir(join(assetRoot, 'languages')),
-  readdir(join(assetRoot, 'themes')),
-])
-assert.equal(languageFiles.filter(file => file.endsWith('.fkgram')).length, languageCatalog.length)
-assert.equal(themeFiles.filter(file => file.endsWith('.fktheme')).length, themeCatalog.length)
+  readdir(join(assetRoot, "languages")),
+  readdir(join(assetRoot, "themes")),
+]);
+assert.equal(
+  languageFiles.filter((file) => file.endsWith(".fkgram")).length,
+  languageCatalog.length,
+);
+assert.equal(themeFiles.filter((file) => file.endsWith(".fktheme")).length, themeCatalog.length);
 
-console.log(`Ferriki catalogs verified: ${languageCatalog.length} languages, ${themeCatalog.length} themes, ${Object.keys(bundledLanguagesAlias).length} aliases`)
+console.log(
+  `Ferriki catalogs verified: ${languageCatalog.length} languages, ${themeCatalog.length} themes, ${Object.keys(bundledLanguagesAlias).length} aliases`,
+);
 
 async function assertAsset(file) {
-  await access(file, constants.R_OK)
+  await access(file, constants.R_OK);
 }
 
 function compareIds(left, right) {
-  return left < right ? -1 : left > right ? 1 : 0
+  return left < right ? -1 : left > right ? 1 : 0;
 }

--- a/node/scripts/check-ferriki-errors.mjs
+++ b/node/scripts/check-ferriki-errors.mjs
@@ -1,80 +1,103 @@
-import assert from 'node:assert/strict'
+import assert from "node:assert/strict";
 import {
   codeToHtml,
   createHighlighterCoreSync,
   FerrikiError,
   ShikiError,
-} from '../ferriki/index.mjs'
+} from "../ferriki/index.mjs";
 
 function hasCode(code) {
   return (error) => {
-    assert(error instanceof ShikiError)
-    assert.equal(error.code, code)
-    return true
-  }
+    assert(error instanceof ShikiError);
+    assert.equal(error.code, code);
+    return true;
+  };
 }
 
-assert.throws(() => createHighlighterCoreSync({ langs: 'javascript' }), hasCode('ERR_USAGE'))
-assert.throws(() => createHighlighterCoreSync({ langAlias: { javascript: 42 } }), hasCode('ERR_USAGE'))
+assert.throws(() => createHighlighterCoreSync({ langs: "javascript" }), hasCode("ERR_USAGE"));
+assert.throws(
+  () => createHighlighterCoreSync({ langAlias: { javascript: 42 } }),
+  hasCode("ERR_USAGE"),
+);
 
 const highlighter = createHighlighterCoreSync({
-  langs: ['javascript'],
-  themes: ['nord'],
-})
+  langs: ["javascript"],
+  themes: ["nord"],
+});
 
 assert.throws(
-  () => highlighter.codeToHtml('const answer = 42', { lang: 'javascript', theme: 'nord', tokenizeTimeLimit: -1 }),
-  hasCode('ERR_USAGE'),
-)
+  () =>
+    highlighter.codeToHtml("const answer = 42", {
+      lang: "javascript",
+      theme: "nord",
+      tokenizeTimeLimit: -1,
+    }),
+  hasCode("ERR_USAGE"),
+);
 assert.throws(
-  () => highlighter.codeToHtml('const answer = 42', { lang: 'javascript', theme: 'nord', engine: {} }),
-  hasCode('ERR_UNSUPPORTED'),
-)
+  () =>
+    highlighter.codeToHtml("const answer = 42", { lang: "javascript", theme: "nord", engine: {} }),
+  hasCode("ERR_UNSUPPORTED"),
+);
 assert.throws(
-  () => highlighter.codeToHtml('const answer = 42', { lang: 'missing-ferriki-language', theme: 'nord' }),
-  hasCode('ERR_UNSUPPORTED'),
-)
+  () =>
+    highlighter.codeToHtml("const answer = 42", {
+      lang: "missing-ferriki-language",
+      theme: "nord",
+    }),
+  hasCode("ERR_UNSUPPORTED"),
+);
 assert.throws(
-  () => highlighter.codeToHtml('\u001B[31mred\u001B[0m', { lang: 'ansi', theme: 'nord' }),
-  hasCode('ERR_UNSUPPORTED'),
-)
+  () => highlighter.codeToHtml("\u001B[31mred\u001B[0m", { lang: "ansi", theme: "nord" }),
+  hasCode("ERR_UNSUPPORTED"),
+);
 
 assert.throws(
-  () => highlighter.loadLanguageSync({ name: 'broken', scopeName: 'source.broken', patterns: 'not-an-array' }),
-  hasCode('ERR_USAGE'),
-)
+  () =>
+    highlighter.loadLanguageSync({
+      name: "broken",
+      scopeName: "source.broken",
+      patterns: "not-an-array",
+    }),
+  hasCode("ERR_USAGE"),
+);
 assert.throws(
-  () => highlighter.loadLanguageSync({ name: 'broken-native', scopeName: 'source.broken', patterns: [{ match: 5 }] }),
+  () =>
+    highlighter.loadLanguageSync({
+      name: "broken-native",
+      scopeName: "source.broken",
+      patterns: [{ match: 5 }],
+    }),
   (error) => {
-    assert(error instanceof ShikiError)
-    assert.equal(error.code, 'ERR_ASSET')
-    assert(error.cause instanceof Error)
-    return true
+    assert(error instanceof ShikiError);
+    assert.equal(error.code, "ERR_ASSET");
+    assert(error.cause instanceof Error);
+    return true;
   },
-)
+);
 assert.throws(
-  () => highlighter.codeToHtml('const answer = 42', { lang: 'javascript' }),
-  hasCode('ERR_USAGE'),
-)
-const limited = highlighter.codeToTokens('const answer = 42', {
-  lang: 'javascript',
-  theme: 'nord',
+  () => highlighter.codeToHtml("const answer = 42", { lang: "javascript" }),
+  hasCode("ERR_USAGE"),
+);
+const limited = highlighter.codeToTokens("const answer = 42", {
+  lang: "javascript",
+  theme: "nord",
   tokenizeMaxLineLength: 4,
-})
-assert.equal(limited.tokens[0][0].color, '')
+});
+assert.equal(limited.tokens[0][0].color, "");
 
-const rendered = await codeToHtml('const answer = 42', { lang: 'javascript', theme: 'nord' })
-assert(rendered.includes('const'))
+const rendered = await codeToHtml("const answer = 42", { lang: "javascript", theme: "nord" });
+assert(rendered.includes("const"));
 
-highlighter.dispose()
+highlighter.dispose();
 assert.throws(
-  () => highlighter.codeToHtml('const answer = 42', { lang: 'javascript', theme: 'nord' }),
-  hasCode('ERR_USAGE'),
-)
+  () => highlighter.codeToHtml("const answer = 42", { lang: "javascript", theme: "nord" }),
+  hasCode("ERR_USAGE"),
+);
 
-const internal = new FerrikiError('internal failure', 'ERR_INTERNAL')
-assert(internal instanceof ShikiError)
-assert.equal(internal.name, 'FerrikiError')
-assert.equal(internal.code, 'ERR_INTERNAL')
+const internal = new FerrikiError("internal failure", "ERR_INTERNAL");
+assert(internal instanceof ShikiError);
+assert.equal(internal.name, "FerrikiError");
+assert.equal(internal.code, "ERR_INTERNAL");
 
-console.log('Ferriki error taxonomy and recovery verified')
+console.log("Ferriki error taxonomy and recovery verified");

--- a/node/scripts/check-ferriki-exports.mjs
+++ b/node/scripts/check-ferriki-exports.mjs
@@ -1,21 +1,21 @@
-import assert from 'node:assert/strict'
-import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const scriptDir = fileURLToPath(new URL('.', import.meta.url))
-const ferriki = await import('../ferriki/index.mjs')
+const scriptDir = fileURLToPath(new URL(".", import.meta.url));
+const ferriki = await import("../ferriki/index.mjs");
 for (const removed of [
-  'createJavaScriptRegexEngine',
-  'createOnigurumaEngine',
-  'loadWasm',
-  'wasmBinary',
-  '__ferrikiBackend',
+  "createJavaScriptRegexEngine",
+  "createOnigurumaEngine",
+  "loadWasm",
+  "wasmBinary",
+  "__ferrikiBackend",
 ]) {
-  assert.equal(Object.hasOwn(ferriki, removed), false, `${removed} must not be public Ferriki API`)
+  assert.equal(Object.hasOwn(ferriki, removed), false, `${removed} must not be public Ferriki API`);
 }
 
-const packageJson = JSON.parse(await readFile(join(scriptDir, '../ferriki/package.json'), 'utf8'))
-assert.deepEqual(Object.keys(packageJson.exports).sort(), ['.', './native', './package.json'])
+const packageJson = JSON.parse(await readFile(join(scriptDir, "../ferriki/package.json"), "utf8"));
+assert.deepEqual(Object.keys(packageJson.exports).sort(), [".", "./native", "./package.json"]);
 
-console.log('Ferriki public export surface verified')
+console.log("Ferriki public export surface verified");

--- a/node/scripts/check-ferriki-multitheme.mjs
+++ b/node/scripts/check-ferriki-multitheme.mjs
@@ -1,67 +1,68 @@
-import assert from 'node:assert/strict'
+import assert from "node:assert/strict";
 
-import { createHighlighter, ShikiError } from '../ferriki/index.mjs'
+import { createHighlighter, ShikiError } from "../ferriki/index.mjs";
 
 const highlighter = await createHighlighter({
-  langs: ['typescript'],
-  themes: ['vitesse-light', 'vitesse-dark'],
-})
+  langs: ["typescript"],
+  themes: ["vitesse-light", "vitesse-dark"],
+});
 
 try {
   const options = {
-    lang: 'typescript',
+    lang: "typescript",
     themes: {
-      light: 'vitesse-light',
-      dark: 'vitesse-dark',
+      light: "vitesse-light",
+      dark: "vitesse-dark",
     },
     defaultColor: false,
-  }
-  const tokens = highlighter.codeToTokens('const answer: number = 42', options)
-  assert.equal(tokens.themeName, 'shiki-themes vitesse-light vitesse-dark')
-  assert.match(tokens.fg, /--shiki-light:/)
-  assert.match(tokens.fg, /--shiki-dark:/)
-  assert(Object.hasOwn(tokens.tokens[0][0], 'htmlStyle'))
-  assert.match(tokens.tokens[0][0].htmlStyle, /--shiki-light:/)
-  assert.match(tokens.tokens[0][0].htmlStyle, /--shiki-dark:/)
+  };
+  const tokens = highlighter.codeToTokens("const answer: number = 42", options);
+  assert.equal(tokens.themeName, "shiki-themes vitesse-light vitesse-dark");
+  assert.match(tokens.fg, /--shiki-light:/);
+  assert.match(tokens.fg, /--shiki-dark:/);
+  assert(Object.hasOwn(tokens.tokens[0][0], "htmlStyle"));
+  assert.match(tokens.tokens[0][0].htmlStyle, /--shiki-light:/);
+  assert.match(tokens.tokens[0][0].htmlStyle, /--shiki-dark:/);
 
-  const html = highlighter.codeToHtml('const answer: number = 42', options)
-  assert.match(html, /class="shiki-themes vitesse-light vitesse-dark"/)
-  assert.match(html, /--shiki-light:/)
-  assert.match(html, /--shiki-dark:/)
+  const html = highlighter.codeToHtml("const answer: number = 42", options);
+  assert.match(html, /class="shiki-themes vitesse-light vitesse-dark"/);
+  assert.match(html, /--shiki-light:/);
+  assert.match(html, /--shiki-dark:/);
 
-  const lightDark = highlighter.codeToHtml('const answer = 42', {
+  const lightDark = highlighter.codeToHtml("const answer = 42", {
     ...options,
-    defaultColor: 'light-dark()',
-  })
-  assert.match(lightDark, /light-dark\(/)
-  assert.match(lightDark, /--shiki-light:/)
-  assert.match(lightDark, /--shiki-dark:/)
+    defaultColor: "light-dark()",
+  });
+  assert.match(lightDark, /light-dark\(/);
+  assert.match(lightDark, /--shiki-light:/);
+  assert.match(lightDark, /--shiki-dark:/);
 
   assert.throws(
-    () => highlighter.codeToHtml('const answer = 42', {
-      lang: 'typescript',
-      themes: { dark: 'vitesse-dark' },
-    }),
-    error => error instanceof ShikiError && error.message.includes('defaultColor key `light`'),
-  )
+    () =>
+      highlighter.codeToHtml("const answer = 42", {
+        lang: "typescript",
+        themes: { dark: "vitesse-dark" },
+      }),
+    (error) => error instanceof ShikiError && error.message.includes("defaultColor key `light`"),
+  );
   assert.throws(
-    () => highlighter.codeToHtml('const answer = 42', {
-      lang: 'typescript',
-      themes: {},
-      defaultColor: false,
-    }),
-    error => error instanceof ShikiError && error.message === '`themes` option must not be empty',
-  )
+    () =>
+      highlighter.codeToHtml("const answer = 42", {
+        lang: "typescript",
+        themes: {},
+        defaultColor: false,
+      }),
+    (error) => error instanceof ShikiError && error.message === "`themes` option must not be empty",
+  );
 
-  const none = highlighter.codeToHtml('const answer = 42', {
-    lang: 'typescript',
-    theme: 'none',
-  })
-  assert.match(none, /class="none"/)
-  assert.match(none, /color:inherit/)
-}
-finally {
-  highlighter.dispose()
+  const none = highlighter.codeToHtml("const answer = 42", {
+    lang: "typescript",
+    theme: "none",
+  });
+  assert.match(none, /class="none"/);
+  assert.match(none, /color:inherit/);
+} finally {
+  highlighter.dispose();
 }
 
-console.log('Ferriki multi-theme contract verified')
+console.log("Ferriki multi-theme contract verified");

--- a/node/scripts/check-ferriki-platform-matrix.mjs
+++ b/node/scripts/check-ferriki-platform-matrix.mjs
@@ -1,42 +1,53 @@
-import assert from 'node:assert/strict'
-import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   FERRIKI_NODE_MIN_VERSION,
   FERRIKI_PLATFORM_TARGETS,
   formatFerrikiPlatformMatrix,
   resolveFerrikiPlatformTarget,
-} from '../ferriki/platforms.mjs'
+} from "../ferriki/platforms.mjs";
 
-const nodeRoot = join(fileURLToPath(new URL('.', import.meta.url)), '..')
-const ferrikiManifest = JSON.parse(await readFile(join(nodeRoot, 'ferriki', 'package.json'), 'utf8'))
+const nodeRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const ferrikiManifest = JSON.parse(
+  await readFile(join(nodeRoot, "ferriki", "package.json"), "utf8"),
+);
 
-assert.equal(FERRIKI_NODE_MIN_VERSION, '22.13.0')
-assert.deepEqual(FERRIKI_PLATFORM_TARGETS.map(target => target.id), [
-  'linux-x64-gnu',
-  'linux-arm64-gnu',
-  'darwin-arm64',
-  'darwin-x64',
-  'win32-x64-msvc',
-])
-assert.equal(resolveFerrikiPlatformTarget({ platform: 'linux', arch: 'x64', libc: 'gnu' }).id, 'linux-x64-gnu')
-assert.equal(resolveFerrikiPlatformTarget({ platform: 'linux', arch: 'x64', libc: 'musl' }), undefined)
-assert.equal(resolveFerrikiPlatformTarget({ platform: 'win32', arch: 'x64' }).id, 'win32-x64-msvc')
-assert.equal(resolveFerrikiPlatformTarget({ platform: 'win32', arch: 'arm64' }), undefined)
-assert.match(formatFerrikiPlatformMatrix(), /linux-arm64-gnu \(Node >= 22\.13\.0\)/)
+assert.equal(FERRIKI_NODE_MIN_VERSION, "22.13.0");
+assert.deepEqual(
+  FERRIKI_PLATFORM_TARGETS.map((target) => target.id),
+  ["linux-x64-gnu", "linux-arm64-gnu", "darwin-arm64", "darwin-x64", "win32-x64-msvc"],
+);
+assert.equal(
+  resolveFerrikiPlatformTarget({ platform: "linux", arch: "x64", libc: "gnu" }).id,
+  "linux-x64-gnu",
+);
+assert.equal(
+  resolveFerrikiPlatformTarget({ platform: "linux", arch: "x64", libc: "musl" }),
+  undefined,
+);
+assert.equal(resolveFerrikiPlatformTarget({ platform: "win32", arch: "x64" }).id, "win32-x64-msvc");
+assert.equal(resolveFerrikiPlatformTarget({ platform: "win32", arch: "arm64" }), undefined);
+assert.match(formatFerrikiPlatformMatrix(), /linux-arm64-gnu \(Node >= 22\.13\.0\)/);
 
 for (const target of FERRIKI_PLATFORM_TARGETS) {
   assert.equal(
     ferrikiManifest.optionalDependencies?.[target.packageName],
     ferrikiManifest.version,
     `${target.id} must be declared as an optional dependency at the package version`,
-  )
-  const sidecar = JSON.parse(await readFile(join(nodeRoot, 'platforms', target.id, 'package.json'), 'utf8'))
-  assert.equal(sidecar.name, target.packageName)
-  assert.equal(sidecar.version, ferrikiManifest.version, `${target.id} sidecar must use the main package version`)
-  assert(sidecar.files.includes('ferriki.node'), `${target.id} sidecar must publish ferriki.node`)
+  );
+  const sidecar = JSON.parse(
+    await readFile(join(nodeRoot, "platforms", target.id, "package.json"), "utf8"),
+  );
+  assert.equal(sidecar.name, target.packageName);
+  assert.equal(
+    sidecar.version,
+    ferrikiManifest.version,
+    `${target.id} sidecar must use the main package version`,
+  );
+  assert(sidecar.files.includes("ferriki.node"), `${target.id} sidecar must publish ferriki.node`);
 }
 
-console.log('Ferriki platform matrix verified (GNU Linux only; musl explicitly unsupported)')
+console.log("Ferriki platform matrix verified (GNU Linux only; musl explicitly unsupported)");

--- a/node/scripts/check-ferriki-registrations.mjs
+++ b/node/scripts/check-ferriki-registrations.mjs
@@ -1,124 +1,128 @@
-import assert from 'node:assert/strict'
+import assert from "node:assert/strict";
 
-import { createHighlighter, createHighlighterCoreSync, ShikiError } from '../ferriki/index.mjs'
+import { createHighlighter, createHighlighterCoreSync, ShikiError } from "../ferriki/index.mjs";
 
 const language = {
-  name: 'ferriki-registration',
-  scopeName: 'source.ferriki-registration',
-  aliases: ['freg', 'js'],
-  patterns: [{ match: '\\bTODO\\b', name: 'keyword.todo.ferriki' }],
-}
+  name: "ferriki-registration",
+  scopeName: "source.ferriki-registration",
+  aliases: ["freg", "js"],
+  patterns: [{ match: "\\bTODO\\b", name: "keyword.todo.ferriki" }],
+};
 const theme = {
-  name: 'ferriki-registration-theme',
-  type: 'light',
-  fg: '#111111',
-  bg: '#ffffff',
-  settings: [{
-    scope: 'keyword.todo.ferriki',
-    settings: { foreground: '#ff00aa', fontStyle: 'bold' },
-  }],
-}
+  name: "ferriki-registration-theme",
+  type: "light",
+  fg: "#111111",
+  bg: "#ffffff",
+  settings: [
+    {
+      scope: "keyword.todo.ferriki",
+      settings: { foreground: "#ff00aa", fontStyle: "bold" },
+    },
+  ],
+};
 const includedTheme = {
-  name: 'ferriki-registration-theme-included',
-  include: 'nord',
-  settings: [{
-    scope: 'keyword.todo.ferriki',
-    settings: { foreground: '#00aaff' },
-  }],
-}
+  name: "ferriki-registration-theme-included",
+  include: "nord",
+  settings: [
+    {
+      scope: "keyword.todo.ferriki",
+      settings: { foreground: "#00aaff" },
+    },
+  ],
+};
 const childLanguage = {
-  name: 'ferriki-registration-child',
-  scopeName: 'source.ferriki-registration-child',
-  patterns: [{ match: '\\bCHILD\\b', name: 'keyword.child' }],
-}
+  name: "ferriki-registration-child",
+  scopeName: "source.ferriki-registration-child",
+  patterns: [{ match: "\\bCHILD\\b", name: "keyword.child" }],
+};
 const parentLanguage = {
-  name: 'ferriki-registration-parent',
-  scopeName: 'source.ferriki-registration-parent',
-  embeddedLangs: ['ferriki-registration-child'],
-  patterns: [{ include: 'source.ferriki-registration-child' }],
-}
+  name: "ferriki-registration-parent",
+  scopeName: "source.ferriki-registration-parent",
+  embeddedLangs: ["ferriki-registration-child"],
+  patterns: [{ include: "source.ferriki-registration-child" }],
+};
 const injectionLanguage = {
-  name: 'ferriki-registration-injection',
-  scopeName: 'source.ferriki-registration-injection',
-  injectTo: ['source.js'],
-  patterns: [{ match: '\\bINJECTED\\b', name: 'keyword.injected' }],
-}
+  name: "ferriki-registration-injection",
+  scopeName: "source.ferriki-registration-injection",
+  injectTo: ["source.js"],
+  patterns: [{ match: "\\bINJECTED\\b", name: "keyword.injected" }],
+};
 
 const highlighter = await createHighlighter({
   langs: [language],
   themes: [theme],
-})
+});
 try {
-  const html = highlighter.codeToHtml('TODO', {
-    lang: 'freg',
-    theme: 'ferriki-registration-theme',
-  })
-  assert.match(html, /ff00aa/i)
+  const html = highlighter.codeToHtml("TODO", {
+    lang: "freg",
+    theme: "ferriki-registration-theme",
+  });
+  assert.match(html, /ff00aa/i);
 
-  const direct = highlighter.codeToHast('TODO', { lang: language, theme })
-  assert.equal(direct.type, 'root')
-  const tokens = highlighter.codeToTokens('TODO', {
-    lang: 'ferriki-registration',
+  const direct = highlighter.codeToHast("TODO", { lang: language, theme });
+  assert.equal(direct.type, "root");
+  const tokens = highlighter.codeToTokens("TODO", {
+    lang: "ferriki-registration",
     theme,
-  })
-  assert.equal(tokens.tokens[0][0].content, 'TODO')
-  assert.equal(tokens.tokens[0][0].color?.toLowerCase(), '#ff00aa')
+  });
+  assert.equal(tokens.tokens[0][0].content, "TODO");
+  assert.equal(tokens.tokens[0][0].color?.toLowerCase(), "#ff00aa");
 
-  highlighter.loadThemeSync(includedTheme)
-  const included = highlighter.codeToHtml('TODO', {
-    lang: 'ferriki-registration',
-    theme: 'ferriki-registration-theme-included',
-  })
-  assert.match(included, /00aaff/i)
+  highlighter.loadThemeSync(includedTheme);
+  const included = highlighter.codeToHtml("TODO", {
+    lang: "ferriki-registration",
+    theme: "ferriki-registration-theme-included",
+  });
+  assert.match(included, /00aaff/i);
 
   // A user alias matching a standard alias must not hide the standard
   // catalog entry, even when the custom registration is loaded first.
-  await highlighter.loadLanguage('js')
-  assert(highlighter.getLoadedLanguages().includes('javascript'))
+  await highlighter.loadLanguage("js");
+  assert(highlighter.getLoadedLanguages().includes("javascript"));
 
   assert.throws(
-    () => highlighter.loadLanguageSync({
-      name: 'invalid-registration',
-      scopeName: 'source.invalid-registration',
-      patterns: [],
-      unsupportedField: true,
-    }),
-    error => error instanceof ShikiError && /Unsupported language registration field/.test(error.message),
-  )
-}
-finally {
-  highlighter.dispose()
+    () =>
+      highlighter.loadLanguageSync({
+        name: "invalid-registration",
+        scopeName: "source.invalid-registration",
+        patterns: [],
+        unsupportedField: true,
+      }),
+    (error) =>
+      error instanceof ShikiError && /Unsupported language registration field/.test(error.message),
+  );
+} finally {
+  highlighter.dispose();
 }
 
 const grammarHighlighter = await createHighlighter({
-  langs: [parentLanguage, childLanguage, injectionLanguage, 'javascript'],
-  themes: ['nord'],
-})
+  langs: [parentLanguage, childLanguage, injectionLanguage, "javascript"],
+  themes: ["nord"],
+});
 try {
-  const child = grammarHighlighter.codeToHtml('CHILD', {
-    lang: 'ferriki-registration-parent',
-    theme: 'nord',
-  })
-  assert.match(child, /CHILD/)
-  const injected = grammarHighlighter.codeToHtml('INJECTED', {
-    lang: 'javascript',
-    theme: 'nord',
-  })
-  assert.match(injected, /INJECTED/)
-}
-finally {
-  grammarHighlighter.dispose()
+  const child = grammarHighlighter.codeToHtml("CHILD", {
+    lang: "ferriki-registration-parent",
+    theme: "nord",
+  });
+  assert.match(child, /CHILD/);
+  const injected = grammarHighlighter.codeToHtml("INJECTED", {
+    lang: "javascript",
+    theme: "nord",
+  });
+  assert.match(injected, /INJECTED/);
+} finally {
+  grammarHighlighter.dispose();
 }
 
 const asyncHighlighter = await createHighlighter({
   langs: [async () => [language]],
   themes: [async () => theme],
-})
-asyncHighlighter.dispose()
+});
+asyncHighlighter.dispose();
 
 assert.throws(
   () => createHighlighterCoreSync({ langs: [() => language] }),
-  error => error instanceof ShikiError && /Async language\/theme input/.test(error.message),
-)
+  (error) => error instanceof ShikiError && /Async language\/theme input/.test(error.message),
+);
 
-console.log('Ferriki custom language/theme registrations verified')
+console.log("Ferriki custom language/theme registrations verified");

--- a/node/scripts/check-ferriki-token-state.mjs
+++ b/node/scripts/check-ferriki-token-state.mjs
@@ -1,79 +1,83 @@
-import assert from 'node:assert/strict'
-import { createHighlighter, ShikiError } from '../ferriki/index.mjs'
+import assert from "node:assert/strict";
+import { createHighlighter, ShikiError } from "../ferriki/index.mjs";
 
 const highlighter = await createHighlighter({
-  langs: ['javascript', 'typescript'],
-  themes: ['nord'],
-})
+  langs: ["javascript", "typescript"],
+  themes: ["nord"],
+});
 
 try {
-  const explained = highlighter.codeToTokens('const 😀 = 1\r\n', {
-    lang: 'javascript',
-    theme: 'nord',
-    includeExplanation: 'scopeName',
-  })
-  const first = explained.tokens[0][0]
-  assert.equal(first.content, 'const')
-  assert.equal(first.offset, 0)
-  assert(first.explanation?.[0]?.scopes.some(scope => scope.scopeName === 'source.js'))
-  assert.equal('scopeNames' in first, false)
+  const explained = highlighter.codeToTokens("const 😀 = 1\r\n", {
+    lang: "javascript",
+    theme: "nord",
+    includeExplanation: "scopeName",
+  });
+  const first = explained.tokens[0][0];
+  assert.equal(first.content, "const");
+  assert.equal(first.offset, 0);
+  assert(first.explanation?.[0]?.scopes.some((scope) => scope.scopeName === "source.js"));
+  assert.equal("scopeNames" in first, false);
 
-  const typed = highlighter.codeToTokens('const x = 1', {
-    lang: 'javascript',
-    theme: 'nord',
-    includeExplanation: 'tokenType',
-  })
-  assert.equal(typed.tokens[0][0].explanation, undefined)
-  assert.equal(typeof typed.tokens[0][0].type, 'number')
+  const typed = highlighter.codeToTokens("const x = 1", {
+    lang: "javascript",
+    theme: "nord",
+    includeExplanation: "tokenType",
+  });
+  assert.equal(typed.tokens[0][0].explanation, undefined);
+  assert.equal(typeof typed.tokens[0][0].type, "number");
 
   const state = highlighter.getLastGrammarState('const value = "', {
-    lang: 'javascript',
-    theme: 'nord',
-  })
-  const roundTripped = JSON.parse(JSON.stringify(state))
-  assert.deepEqual(roundTripped, state)
+    lang: "javascript",
+    theme: "nord",
+  });
+  const roundTripped = JSON.parse(JSON.stringify(state));
+  assert.deepEqual(roundTripped, state);
   const natural = highlighter.codeToTokens('text"', {
-    lang: 'javascript',
-    theme: 'nord',
-  })
+    lang: "javascript",
+    theme: "nord",
+  });
   const continued = highlighter.codeToTokens('text"', {
-    lang: 'javascript',
-    theme: 'nord',
+    lang: "javascript",
+    theme: "nord",
     grammarState: roundTripped,
-  })
-  assert.notDeepEqual(continued.tokens, natural.tokens)
-  assert.deepEqual(continued, highlighter.codeToTokens('text"', {
-    lang: 'javascript',
-    theme: 'nord',
-    grammarState: roundTripped,
-  }))
+  });
+  assert.notDeepEqual(continued.tokens, natural.tokens);
+  assert.deepEqual(
+    continued,
+    highlighter.codeToTokens('text"', {
+      lang: "javascript",
+      theme: "nord",
+      grammarState: roundTripped,
+    }),
+  );
 
   assert.throws(
-    () => highlighter.codeToTokens('x', {
-      lang: 'typescript',
-      theme: 'nord',
-      grammarState: state,
-    }),
-    error => error instanceof ShikiError && error.code === 'ERR_USAGE',
-  )
+    () =>
+      highlighter.codeToTokens("x", {
+        lang: "typescript",
+        theme: "nord",
+        grammarState: state,
+      }),
+    (error) => error instanceof ShikiError && error.code === "ERR_USAGE",
+  );
   assert.throws(
-    () => highlighter.codeToTokens('x', {
-      lang: 'javascript',
-      theme: 'nord',
-      grammarState: { lang: 'javascript', themes: ['nord'] },
-    }),
-    error => error instanceof ShikiError && error.code === 'ERR_USAGE',
-  )
+    () =>
+      highlighter.codeToTokens("x", {
+        lang: "javascript",
+        theme: "nord",
+        grammarState: { lang: "javascript", themes: ["nord"] },
+      }),
+    (error) => error instanceof ShikiError && error.code === "ERR_USAGE",
+  );
 
-  const themes = highlighter.codeToTokens('let value = 1', {
-    lang: 'javascript',
-    themes: { light: 'nord', dark: 'nord' },
-  })
-  assert(themes.grammarState)
-  assert.equal(themes.tokens[0][0].variants.light.color, themes.tokens[0][0].variants.dark.color)
-}
-finally {
-  highlighter.dispose()
+  const themes = highlighter.codeToTokens("let value = 1", {
+    lang: "javascript",
+    themes: { light: "nord", dark: "nord" },
+  });
+  assert(themes.grammarState);
+  assert.equal(themes.tokens[0][0].variants.light.color, themes.tokens[0][0].variants.dark.color);
+} finally {
+  highlighter.dispose();
 }
 
-console.log('Ferriki token explanation and grammar-state contract verified')
+console.log("Ferriki token explanation and grammar-state contract verified");

--- a/node/scripts/check-ferriki-transformers.mjs
+++ b/node/scripts/check-ferriki-transformers.mjs
@@ -1,85 +1,89 @@
-import assert from 'node:assert/strict'
-import { createHighlighter, ShikiError } from '../ferriki/index.mjs'
+import assert from "node:assert/strict";
+import { createHighlighter, ShikiError } from "../ferriki/index.mjs";
 
 const highlighter = await createHighlighter({
-  langs: ['javascript'],
-  themes: ['nord'],
-})
+  langs: ["javascript"],
+  themes: ["nord"],
+});
 
 try {
-  const calls = []
-  const html = highlighter.codeToHtml('const answer = 42', {
-    lang: 'javascript',
-    theme: 'nord',
-    meta: { title: 'demo' },
-    transformers: [{
-      preprocess(code) {
-        calls.push('preprocess')
-        return code
+  const calls = [];
+  const html = highlighter.codeToHtml("const answer = 42", {
+    lang: "javascript",
+    theme: "nord",
+    meta: { title: "demo" },
+    transformers: [
+      {
+        preprocess(code) {
+          calls.push("preprocess");
+          return code;
+        },
+        tokens(tokens) {
+          calls.push("tokens");
+          return tokens;
+        },
+        span(node) {
+          calls.push("span");
+          node.properties.class = "token";
+          return node;
+        },
+        line(node) {
+          calls.push("line");
+          return node;
+        },
+        code(node) {
+          calls.push("code");
+          return node;
+        },
+        pre(node) {
+          calls.push("pre");
+          return node;
+        },
+        root(node) {
+          calls.push("root");
+          return node;
+        },
+        postprocess(value) {
+          calls.push("postprocess");
+          return `${value}<!-- transformed -->`;
+        },
       },
-      tokens(tokens) {
-        calls.push('tokens')
-        return tokens
-      },
-      span(node) {
-        calls.push('span')
-        node.properties.class = 'token'
-        return node
-      },
-      line(node) {
-        calls.push('line')
-        return node
-      },
-      code(node) {
-        calls.push('code')
-        return node
-      },
-      pre(node) {
-        calls.push('pre')
-        return node
-      },
-      root(node) {
-        calls.push('root')
-        return node
-      },
-      postprocess(value) {
-        calls.push('postprocess')
-        return `${value}<!-- transformed -->`
-      },
-    }],
-  })
-  assert.match(html, /title="demo"/)
-  assert.match(html, /class="token"/)
-  assert.match(html, /<!-- transformed -->/)
-  assert.deepEqual(calls.slice(0, 3), ['preprocess', 'tokens', 'span'])
-  assert.equal(calls.at(-1), 'postprocess')
-  assert(calls.includes('line'))
-  assert(calls.includes('code'))
-  assert(calls.includes('pre'))
-  assert(calls.includes('root'))
+    ],
+  });
+  assert.match(html, /title="demo"/);
+  assert.match(html, /class="token"/);
+  assert.match(html, /<!-- transformed -->/);
+  assert.deepEqual(calls.slice(0, 3), ["preprocess", "tokens", "span"]);
+  assert.equal(calls.at(-1), "postprocess");
+  assert(calls.includes("line"));
+  assert(calls.includes("code"));
+  assert(calls.includes("pre"));
+  assert(calls.includes("root"));
 
-  const decorated = highlighter.codeToHtml('alpha\nbeta', {
-    lang: 'text',
-    theme: 'nord',
-    decorations: [{
-      start: { line: 0, character: 1 },
-      end: { line: 1, character: 2 },
-      properties: { class: 'marked' },
-    }],
-  })
-  assert.match(decorated, /class="marked"/)
+  const decorated = highlighter.codeToHtml("alpha\nbeta", {
+    lang: "text",
+    theme: "nord",
+    decorations: [
+      {
+        start: { line: 0, character: 1 },
+        end: { line: 1, character: 2 },
+        properties: { class: "marked" },
+      },
+    ],
+  });
+  assert.match(decorated, /class="marked"/);
 
   assert.throws(
-    () => highlighter.codeToHtml('alpha', {
-      lang: 'text',
-      theme: 'nord',
-      decorations: [{ start: 3, end: 1 }],
-    }),
-    error => error instanceof ShikiError && error.code === 'ERR_USAGE',
-  )
-}
-finally {
-  highlighter.dispose()
+    () =>
+      highlighter.codeToHtml("alpha", {
+        lang: "text",
+        theme: "nord",
+        decorations: [{ start: 3, end: 1 }],
+      }),
+    (error) => error instanceof ShikiError && error.code === "ERR_USAGE",
+  );
+} finally {
+  highlighter.dispose();
 }
 
-console.log('Ferriki transformer and decoration contract verified')
+console.log("Ferriki transformer and decoration contract verified");

--- a/node/scripts/check-ferromark-ardo-contract.mjs
+++ b/node/scripts/check-ferromark-ardo-contract.mjs
@@ -1,51 +1,53 @@
-import assert from 'node:assert/strict'
-import { readFile } from 'node:fs/promises'
-import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-process.env.FERRIKI_PACKAGE_PATH = new URL('../ferriki/index.mjs', import.meta.url).href
-const exampleModuleUrl = new URL('../../docs/examples/ferromark-ardo.mjs', import.meta.url)
-const { createFerrikiCodeHighlighter } = await import(exampleModuleUrl.href)
+process.env.FERRIKI_PACKAGE_PATH = new URL("../ferriki/index.mjs", import.meta.url).href;
+const exampleModuleUrl = new URL("../../docs/examples/ferromark-ardo.mjs", import.meta.url);
+const { createFerrikiCodeHighlighter } = await import(exampleModuleUrl.href);
 
-const exampleSource = await readFile(fileURLToPath(new URL('../../docs/examples/ferromark-ardo.mjs', import.meta.url)), 'utf8')
-assert(!exampleSource.includes('native.'))
-assert(!exampleSource.includes('resolveGrammarScope'))
+const exampleSource = await readFile(
+  fileURLToPath(new URL("../../docs/examples/ferromark-ardo.mjs", import.meta.url)),
+  "utf8",
+);
+assert(!exampleSource.includes("native."));
+assert(!exampleSource.includes("resolveGrammarScope"));
 
-const diagnostics = []
+const diagnostics = [];
 const adapter = await createFerrikiCodeHighlighter({
-  languages: ['typescript'],
-  onDiagnostic: diagnostic => diagnostics.push(diagnostic),
-})
+  languages: ["typescript"],
+  onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+});
 
 try {
-  const html = adapter.codeToHtml('const answer = 42', {
-    lang: 'typescript',
+  const html = adapter.codeToHtml("const answer = 42", {
+    lang: "typescript",
     meta: { __raw: '{title="trusted-by-ardo" label="example"}' },
-  })
-  assert.match(html, /class="shiki-themes vitesse-light nord"/)
-  assert.match(html, /class="line"/)
-  assert.match(html, /--shiki-light:/)
-  assert.match(html, /--shiki-dark:/)
-  assert(!html.includes('trusted-by-ardo'))
-  assert(!html.includes('example'))
+  });
+  assert.match(html, /class="shiki-themes vitesse-light nord"/);
+  assert.match(html, /class="line"/);
+  assert.match(html, /--shiki-light:/);
+  assert.match(html, /--shiki-dark:/);
+  assert(!html.includes("trusted-by-ardo"));
+  assert(!html.includes("example"));
 
-  const escaped = adapter.codeToHtml('<script>alert("x")</script>', { lang: 'text' })
-  assert(!escaped.includes('<script>'))
-  assert(escaped.includes('&#x3C;script>'))
+  const escaped = adapter.codeToHtml('<script>alert("x")</script>', { lang: "text" });
+  assert(!escaped.includes("<script>"));
+  assert(escaped.includes("&#x3C;script>"));
 
-  const fallback = adapter.codeToHtml('<img src=x onerror=alert(1)>', {
-    lang: 'missing-language',
+  const fallback = adapter.codeToHtml("<img src=x onerror=alert(1)>", {
+    lang: "missing-language",
     meta: { __raw: '{title="untrusted"}' },
-  })
-  assert.match(fallback, /ferriki-fallback language-missing-language/)
-  assert(fallback.includes('&lt;img'))
-  assert(!fallback.includes('untrusted'))
-  assert.equal(diagnostics.length, 1)
-  assert.equal(diagnostics[0].code, 'FERRIKI_HIGHLIGHT_FALLBACK')
-  assert.match(diagnostics[0].message, /missing-language/)
-}
-finally {
-  adapter.dispose()
+  });
+  assert.match(fallback, /ferriki-fallback language-missing-language/);
+  assert(fallback.includes("&lt;img"));
+  assert(!fallback.includes("untrusted"));
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].code, "FERRIKI_HIGHLIGHT_FALLBACK");
+  assert.match(diagnostics[0].message, /missing-language/);
+} finally {
+  adapter.dispose();
 }
 
-console.log('Ferriki + Ferromark + Ardo contract verified')
+console.log("Ferriki + Ferromark + Ardo contract verified");

--- a/node/scripts/check-generated-api.mjs
+++ b/node/scripts/check-generated-api.mjs
@@ -1,22 +1,27 @@
-import { spawnSync } from 'node:child_process'
+import { spawnSync } from "node:child_process";
 
-const result = spawnSync('git', [
-  'diff',
-  '--exit-code',
-  '--',
-  'ferriki/index.mjs',
-  'ferriki/index.d.mts',
-  'ferriki/src/api.d.mts',
-], {
-  cwd: new URL('..', import.meta.url),
-  stdio: 'inherit',
-})
+const result = spawnSync(
+  "git",
+  [
+    "diff",
+    "--exit-code",
+    "--",
+    "ferriki/index.mjs",
+    "ferriki/index.d.mts",
+    "ferriki/src/api.d.mts",
+  ],
+  {
+    cwd: new URL("..", import.meta.url),
+    stdio: "inherit",
+  },
+);
 
-if (result.error)
-  throw result.error
+if (result.error) throw result.error;
 
 if (result.status !== 0) {
-  throw new Error('Generated Ferriki API files are stale; run `pnpm run build` and commit the result.')
+  throw new Error(
+    "Generated Ferriki API files are stale; run `pnpm run build` and commit the result.",
+  );
 }
 
-console.log('[ferriki] Generated API files match the checked-in source')
+console.log("[ferriki] Generated API files match the checked-in source");

--- a/node/scripts/check-native-boundary.mjs
+++ b/node/scripts/check-native-boundary.mjs
@@ -1,55 +1,61 @@
-import assert from 'node:assert/strict'
-import { readdir, readFile } from 'node:fs/promises'
-import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const nodeRoot = join(fileURLToPath(new URL('.', import.meta.url)), '..')
-const packageRoot = join(nodeRoot, 'ferriki')
-const packageJson = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'))
+const nodeRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const packageRoot = join(nodeRoot, "ferriki");
+const packageJson = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8"));
 
 assert.deepEqual(
   Object.keys(packageJson.exports).sort(),
-  ['.', './native', './package.json'],
-  'Ferriki must expose only the high-level API, native loader, and package metadata',
-)
+  [".", "./native", "./package.json"],
+  "Ferriki must expose only the high-level API, native loader, and package metadata",
+);
 
-for (const field of ['dependencies', 'optionalDependencies', 'peerDependencies']) {
-  const values = packageJson[field] || {}
+for (const field of ["dependencies", "optionalDependencies", "peerDependencies"]) {
+  const values = packageJson[field] || {};
   for (const dependency of Object.keys(values)) {
-    assert(!/shiki|wasm|oniguruma|regex|textmate/i.test(dependency), `native-only package must not declare a legacy runtime dependency: ${dependency}`)
+    assert(
+      !/shiki|wasm|oniguruma|regex|textmate/i.test(dependency),
+      `native-only package must not declare a legacy runtime dependency: ${dependency}`,
+    );
   }
 }
 
-const nativeLoader = await readFile(join(packageRoot, 'native.mjs'), 'utf8')
-const forbiddenText = [
-  'FERRIKI_BACKEND',
-  'createJavaScriptRegexEngine',
-  'createOnigurumaEngine',
-]
+const nativeLoader = await readFile(join(packageRoot, "native.mjs"), "utf8");
+const forbiddenText = ["FERRIKI_BACKEND", "createJavaScriptRegexEngine", "createOnigurumaEngine"];
 
 for (const phrase of forbiddenText)
-  assert(!nativeLoader.includes(phrase), `native.mjs reintroduces removed runtime capability: ${phrase}`)
+  assert(
+    !nativeLoader.includes(phrase),
+    `native.mjs reintroduces removed runtime capability: ${phrase}`,
+  );
 
-const forbiddenExtensions = ['.wasm', '.mjs.map']
-const forbiddenPath = /(?:^|\/)(?:chunks|shiki-rust|engine-javascript|engine-oniguruma)(?:\/|$)/
+const forbiddenExtensions = [".wasm", ".mjs.map"];
+const forbiddenPath = /(?:^|\/)(?:chunks|shiki-rust|engine-javascript|engine-oniguruma)(?:\/|$)/;
 
-async function walk(relative = '') {
-  const directory = join(packageRoot, relative)
-  const entries = await readdir(directory, { withFileTypes: true })
-  const files = []
+async function walk(relative = "") {
+  const directory = join(packageRoot, relative);
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
   for (const entry of entries) {
-    const child = relative ? `${relative}/${entry.name}` : entry.name
-    if (entry.isDirectory())
-      files.push(...await walk(child))
-    else
-      files.push(child)
+    const child = relative ? `${relative}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) files.push(...(await walk(child)));
+    else files.push(child);
   }
-  return files
+  return files;
 }
 
 for (const relative of await walk()) {
-  assert(!forbiddenPath.test(relative), `native-only package contains forbidden runtime path: ${relative}`)
-  assert(!forbiddenExtensions.some(extension => relative.endsWith(extension)), `native-only package contains forbidden runtime file: ${relative}`)
+  assert(
+    !forbiddenPath.test(relative),
+    `native-only package contains forbidden runtime path: ${relative}`,
+  );
+  assert(
+    !forbiddenExtensions.some((extension) => relative.endsWith(extension)),
+    `native-only package contains forbidden runtime file: ${relative}`,
+  );
 }
 
-console.log('Ferriki native-only package boundary verified')
+console.log("Ferriki native-only package boundary verified");

--- a/node/scripts/check-packed-consumer.mjs
+++ b/node/scripts/check-packed-consumer.mjs
@@ -1,66 +1,91 @@
-import assert from 'node:assert/strict'
-import { spawnSync } from 'node:child_process'
-import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-const nodeRoot = join(fileURLToPath(new URL('.', import.meta.url)), '..')
-const packageRoot = join(nodeRoot, 'ferriki')
-const examplePath = join(nodeRoot, '..', 'docs', 'examples', 'ferromark-ardo.mjs')
-const tempRoot = await mkdtemp(join(tmpdir(), 'ferriki-docs-consumer-'))
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const nodeRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const packageRoot = join(nodeRoot, "ferriki");
+const examplePath = join(nodeRoot, "..", "docs", "examples", "ferromark-ardo.mjs");
+const tempRoot = await mkdtemp(join(tmpdir(), "ferriki-docs-consumer-"));
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: options.cwd || packageRoot,
-    encoding: 'utf8',
-    stdio: options.stdio || 'pipe',
-    shell: process.platform === 'win32' && command === 'npm.cmd',
+    encoding: "utf8",
+    stdio: options.stdio || "pipe",
+    shell: process.platform === "win32" && command === "npm.cmd",
     env: {
       ...process.env,
-      npm_config_cache: join(tempRoot, 'npm-cache'),
-      npm_config_update_notifier: 'false',
+      npm_config_cache: join(tempRoot, "npm-cache"),
+      npm_config_update_notifier: "false",
       ...options.env,
     },
     ...options,
-  })
+  });
   if (result.status !== 0) {
-    throw new Error(`${command} ${args.join(' ')} failed with ${result.status}\n${result.error || ''}\n${result.stdout || ''}\n${result.stderr || ''}`)
+    throw new Error(
+      `${command} ${args.join(" ")} failed with ${result.status}\n${result.error || ""}\n${result.stdout || ""}\n${result.stderr || ""}`,
+    );
   }
-  return result
+  return result;
 }
 
 try {
-  const packed = run(npmCommand, ['pack', '--json', '--pack-destination', tempRoot])
-  const metadata = JSON.parse(packed.stdout)[0]
-  const files = new Set(metadata.files.map(file => file.path))
-  for (const required of ['index.mjs', 'index.d.mts', 'native.mjs', 'assets/shiki/catalog.mjs'])
-    assert(files.has(required), `packed Ferriki package is missing ${required}`)
-  assert([...files].some(file => /^dist\/ferriki\..+\.node$/.test(file)), 'packed Ferriki package is missing its platform addon')
+  const packed = run(npmCommand, ["pack", "--json", "--pack-destination", tempRoot]);
+  const metadata = JSON.parse(packed.stdout)[0];
+  const files = new Set(metadata.files.map((file) => file.path));
+  for (const required of ["index.mjs", "index.d.mts", "native.mjs", "assets/shiki/catalog.mjs"])
+    assert(files.has(required), `packed Ferriki package is missing ${required}`);
+  assert(
+    [...files].some((file) => /^dist\/ferriki\..+\.node$/.test(file)),
+    "packed Ferriki package is missing its platform addon",
+  );
   const forbidden = [
-    file => file.startsWith('dist/chunks/'),
-    file => file.endsWith('.wasm'),
-    file => file.includes('shiki-rust'),
-    file => file.includes('createJavaScriptRegexEngine'),
-  ]
+    (file) => file.startsWith("dist/chunks/"),
+    (file) => file.endsWith(".wasm"),
+    (file) => file.includes("shiki-rust"),
+    (file) => file.includes("createJavaScriptRegexEngine"),
+  ];
   for (const file of files)
-    assert(!forbidden.some(predicate => predicate(file)), `packed Ferriki package contains forbidden runtime file ${file}`)
-  assert(metadata.unpackedSize < 20_000_000, `packed Ferriki package exceeds the 20 MB unpacked budget (${metadata.unpackedSize})`)
+    assert(
+      !forbidden.some((predicate) => predicate(file)),
+      `packed Ferriki package contains forbidden runtime file ${file}`,
+    );
+  assert(
+    metadata.unpackedSize < 20_000_000,
+    `packed Ferriki package exceeds the 20 MB unpacked budget (${metadata.unpackedSize})`,
+  );
 
-  const tarball = join(tempRoot, metadata.filename)
-  const consumer = await mkdtemp(join(tempRoot, 'consumer-'))
-  run(npmCommand, ['init', '--yes'], { cwd: consumer, stdio: 'ignore' })
+  const tarball = join(tempRoot, metadata.filename);
+  const consumer = await mkdtemp(join(tempRoot, "consumer-"));
+  run(npmCommand, ["init", "--yes"], { cwd: consumer, stdio: "ignore" });
   // Sidecars are published independently. The main-package smoke intentionally
   // omits them so this gate remains runnable before the first coordinated npm release.
-  run(npmCommand, ['install', '--ignore-scripts', '--omit=optional', '--offline', '--no-audit', '--no-fund', tarball], { cwd: consumer, stdio: 'ignore' })
-  const consumerExample = join(consumer, 'ferromark-ardo.mjs')
-  await cp(examplePath, consumerExample)
-  run(process.execPath, [consumerExample], { cwd: consumer, stdio: 'inherit' })
+  run(
+    npmCommand,
+    [
+      "install",
+      "--ignore-scripts",
+      "--omit=optional",
+      "--offline",
+      "--no-audit",
+      "--no-fund",
+      tarball,
+    ],
+    { cwd: consumer, stdio: "ignore" },
+  );
+  const consumerExample = join(consumer, "ferromark-ardo.mjs");
+  await cp(examplePath, consumerExample);
+  run(process.execPath, [consumerExample], { cwd: consumer, stdio: "inherit" });
 
-  const consumerProbe = join(consumer, 'packed-probe.mjs')
-  await writeFile(consumerProbe, `
+  const consumerProbe = join(consumer, "packed-probe.mjs");
+  await writeFile(
+    consumerProbe,
+    `
 import { codeToHast, codeToHtml, codeToTokens, createHighlighter } from 'ferriki'
 import { tryLoadFerrikiNativeBinding } from 'ferriki/native'
 
@@ -89,11 +114,14 @@ const lazy = await createHighlighter({ themes: ['nord'] })
 await lazy.loadLanguage('typescript')
 if (!lazy.codeToTokens('const answer: number = 42', { lang: 'typescript', theme: 'nord' }).tokens.length)
   throw new Error('packed lazy language loading did not produce tokens')
-`)
-  run(process.execPath, [consumerProbe], { cwd: consumer, stdio: 'inherit' })
+`,
+  );
+  run(process.execPath, [consumerProbe], { cwd: consumer, stdio: "inherit" });
 
-  const typecheck = join(consumer, 'packed-types.mts')
-  await writeFile(typecheck, `
+  const typecheck = join(consumer, "packed-types.mts");
+  await writeFile(
+    typecheck,
+    `
 import { codeToHtml, createHighlighter } from 'ferriki'
 
 const highlighter = await createHighlighter({ themes: ['nord'] })
@@ -101,20 +129,40 @@ const html: string = highlighter.codeToHtml('const answer = 42', { lang: 'javasc
 const oneShot: Promise<string> = codeToHtml('const answer = 42', { lang: 'javascript', theme: 'nord' })
 void html
 void oneShot
-`)
-  const tsc = join(nodeRoot, 'node_modules', 'typescript', 'bin', 'tsc')
-  run(process.execPath, [tsc, '--noEmit', '--module', 'NodeNext', '--moduleResolution', 'NodeNext', '--target', 'ES2022', '--skipLibCheck', typecheck], {
-    cwd: consumer,
-  })
+`,
+  );
+  const tsc = join(nodeRoot, "node_modules", "typescript", "bin", "tsc");
+  run(
+    process.execPath,
+    [
+      tsc,
+      "--noEmit",
+      "--module",
+      "NodeNext",
+      "--moduleResolution",
+      "NodeNext",
+      "--target",
+      "ES2022",
+      "--skipLibCheck",
+      typecheck,
+    ],
+    {
+      cwd: consumer,
+    },
+  );
 
-  const installedReadme = await readFile(join(consumer, 'node_modules', 'ferriki', 'README.md'), 'utf8')
-  const { description } = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'))
+  const installedReadme = await readFile(
+    join(consumer, "node_modules", "ferriki", "README.md"),
+    "utf8",
+  );
+  const { description } = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8"));
   assert(
-    installedReadme.replace(/\s+/g, ' ').includes(`Ferriki is ${description}`),
+    installedReadme.replace(/\s+/g, " ").includes(`Ferriki is ${description}`),
     `packed README was not installed, or its tagline no longer matches the package description: ${description}`,
-  )
-  console.log(`Ferriki packed consumer verified (${metadata.filename}, ${metadata.unpackedSize} bytes unpacked, ${files.size} files)`)
-}
-finally {
-  await rm(tempRoot, { recursive: true, force: true })
+  );
+  console.log(
+    `Ferriki packed consumer verified (${metadata.filename}, ${metadata.unpackedSize} bytes unpacked, ${files.size} files)`,
+  );
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
 }

--- a/node/scripts/check-packed-sidecar.mjs
+++ b/node/scripts/check-packed-sidecar.mjs
@@ -1,12 +1,12 @@
-import assert from 'node:assert/strict'
-import { spawnSync } from 'node:child_process'
-import { mkdtemp, readdir, rm, stat, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-import { FERRIKI_PLATFORM_TARGETS, resolveFerrikiPlatformTarget } from '../ferriki/platforms.mjs'
+import { FERRIKI_PLATFORM_TARGETS, resolveFerrikiPlatformTarget } from "../ferriki/platforms.mjs";
 
 // The packed-consumer check installs ferriki without optional dependencies and
 // therefore only ever exercises the bundled addon. This check does the
@@ -16,92 +16,135 @@ import { FERRIKI_PLATFORM_TARGETS, resolveFerrikiPlatformTarget } from '../ferri
 // package name. A negative control then removes the sidecar addon as well and
 // expects the documented failure, so a green run cannot be a fallback in
 // disguise.
-const nodeRoot = join(fileURLToPath(new URL('.', import.meta.url)), '..')
-const packageRoot = join(nodeRoot, 'ferriki')
-const platformId = process.env.FERRIKI_PLATFORM_ID ?? resolveFerrikiPlatformTarget()?.id
-assert(platformId, 'FERRIKI_PLATFORM_ID is required on a platform Ferriki does not support natively')
-const target = FERRIKI_PLATFORM_TARGETS.find(entry => entry.id === platformId)
-assert(target, `unknown Ferriki platform id ${platformId}`)
-const sidecarRoot = join(nodeRoot, 'platforms', platformId)
-const sidecarAddon = join(sidecarRoot, 'ferriki.node')
+const nodeRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const packageRoot = join(nodeRoot, "ferriki");
+const platformId = process.env.FERRIKI_PLATFORM_ID ?? resolveFerrikiPlatformTarget()?.id;
+assert(
+  platformId,
+  "FERRIKI_PLATFORM_ID is required on a platform Ferriki does not support natively",
+);
+const target = FERRIKI_PLATFORM_TARGETS.find((entry) => entry.id === platformId);
+assert(target, `unknown Ferriki platform id ${platformId}`);
+const sidecarRoot = join(nodeRoot, "platforms", platformId);
+const sidecarAddon = join(sidecarRoot, "ferriki.node");
 await stat(sidecarAddon).catch(() => {
-  throw new Error(`${sidecarAddon} is missing; run build:native with FERRIKI_PLATFORM_ID=${platformId} first`)
-})
+  throw new Error(
+    `${sidecarAddon} is missing; run build:native with FERRIKI_PLATFORM_ID=${platformId} first`,
+  );
+});
 
-const tempRoot = await mkdtemp(join(tmpdir(), 'ferriki-sidecar-consumer-'))
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const tempRoot = await mkdtemp(join(tmpdir(), "ferriki-sidecar-consumer-"));
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: options.cwd || packageRoot,
-    encoding: 'utf8',
-    stdio: options.stdio || 'pipe',
-    shell: process.platform === 'win32' && command === 'npm.cmd',
+    encoding: "utf8",
+    stdio: options.stdio || "pipe",
+    shell: process.platform === "win32" && command === "npm.cmd",
     env: {
       ...process.env,
-      npm_config_cache: join(tempRoot, 'npm-cache'),
-      npm_config_update_notifier: 'false',
+      npm_config_cache: join(tempRoot, "npm-cache"),
+      npm_config_update_notifier: "false",
     },
-  })
-  if (options.allowFailure)
-    return result
+  });
+  if (options.allowFailure) return result;
   if (result.status !== 0)
-    throw new Error(`${command} ${args.join(' ')} failed with ${result.status}\n${result.error || ''}\n${result.stdout || ''}\n${result.stderr || ''}`)
-  return result
+    throw new Error(
+      `${command} ${args.join(" ")} failed with ${result.status}\n${result.error || ""}\n${result.stdout || ""}\n${result.stderr || ""}`,
+    );
+  return result;
 }
 
 function pack(cwd) {
-  const packed = run(npmCommand, ['pack', '--json', '--pack-destination', tempRoot], { cwd })
-  return JSON.parse(packed.stdout)[0]
+  const packed = run(npmCommand, ["pack", "--json", "--pack-destination", tempRoot], { cwd });
+  return JSON.parse(packed.stdout)[0];
 }
 
 try {
-  const main = pack(packageRoot)
-  const sidecar = pack(sidecarRoot)
-  assert.equal(sidecar.name, target.packageName, `sidecar tarball is ${sidecar.name}, expected ${target.packageName}`)
+  const main = pack(packageRoot);
+  const sidecar = pack(sidecarRoot);
+  assert.equal(
+    sidecar.name,
+    target.packageName,
+    `sidecar tarball is ${sidecar.name}, expected ${target.packageName}`,
+  );
 
-  const consumer = await mkdtemp(join(tempRoot, 'consumer-'))
-  run(npmCommand, ['init', '--yes'], { cwd: consumer, stdio: 'ignore' })
-  run(npmCommand, ['install', '--ignore-scripts', '--offline', '--no-audit', '--no-fund', join(tempRoot, main.filename), join(tempRoot, sidecar.filename)], { cwd: consumer, stdio: 'ignore' })
+  const consumer = await mkdtemp(join(tempRoot, "consumer-"));
+  run(npmCommand, ["init", "--yes"], { cwd: consumer, stdio: "ignore" });
+  run(
+    npmCommand,
+    [
+      "install",
+      "--ignore-scripts",
+      "--offline",
+      "--no-audit",
+      "--no-fund",
+      join(tempRoot, main.filename),
+      join(tempRoot, sidecar.filename),
+    ],
+    { cwd: consumer, stdio: "ignore" },
+  );
 
-  const installedMain = join(consumer, 'node_modules', 'ferriki')
-  const installedSidecarAddon = join(consumer, 'node_modules', ...target.packageName.split('/'), 'ferriki.node')
-  await stat(installedSidecarAddon)
+  const installedMain = join(consumer, "node_modules", "ferriki");
+  const installedSidecarAddon = join(
+    consumer,
+    "node_modules",
+    ...target.packageName.split("/"),
+    "ferriki.node",
+  );
+  await stat(installedSidecarAddon);
 
   // Leave the sidecar as the only addon the loader could possibly find.
-  const bundled = []
-  for (const directory of [installedMain, join(installedMain, 'dist')]) {
+  const bundled = [];
+  for (const directory of [installedMain, join(installedMain, "dist")]) {
     for (const entry of await readdir(directory).catch(() => [])) {
-      if (entry.endsWith('.node'))
-        bundled.push(join(directory, entry))
+      if (entry.endsWith(".node")) bundled.push(join(directory, entry));
     }
   }
-  assert(bundled.length > 0, 'the packed main package carried no bundled addon to strip; the check would prove nothing')
-  for (const file of bundled)
-    await rm(file, { force: true })
+  assert(
+    bundled.length > 0,
+    "the packed main package carried no bundled addon to strip; the check would prove nothing",
+  );
+  for (const file of bundled) await rm(file, { force: true });
 
-  const probe = join(consumer, 'sidecar-probe.mjs')
-  await writeFile(probe, `
+  const probe = join(consumer, "sidecar-probe.mjs");
+  await writeFile(
+    probe,
+    `
 import { loadFerrikiNativeBinding } from 'ferriki/native'
 
 const version = loadFerrikiNativeBinding().ferrikiVersion()
 if (!version)
   throw new Error('the sidecar-backed ferriki/native export did not load')
 console.log(\`ferriki native core \${version} loaded from ${target.packageName}\`)
-`)
-  run(process.execPath, [probe], { cwd: consumer, stdio: 'inherit' })
+`,
+  );
+  run(process.execPath, [probe], { cwd: consumer, stdio: "inherit" });
 
   // Negative control: with the sidecar addon gone too, the loader must fail and
   // must name the sidecar in what it tried, so the recovery hint in the error
   // points at the package that actually fixes it.
-  await rm(installedSidecarAddon, { force: true })
-  const failure = run(process.execPath, [probe], { cwd: consumer, allowFailure: true })
-  assert.notEqual(failure.status, 0, 'the loader still loaded an addon after every candidate was removed')
-  assert.match(failure.stderr, new RegExp(`No native binary for ${platformId}`), `unexpected loader failure:\n${failure.stderr}`)
-  assert(failure.stderr.includes(`${target.packageName}/ferriki.node`), `loader failure does not list the sidecar candidate:\n${failure.stderr}`)
+  await rm(installedSidecarAddon, { force: true });
+  const failure = run(process.execPath, [probe], { cwd: consumer, allowFailure: true });
+  assert.notEqual(
+    failure.status,
+    0,
+    "the loader still loaded an addon after every candidate was removed",
+  );
+  assert.match(
+    failure.stderr,
+    new RegExp(`No native binary for ${platformId}`),
+    `unexpected loader failure:\n${failure.stderr}`,
+  );
+  assert(
+    failure.stderr.includes(`${target.packageName}/ferriki.node`),
+    `loader failure does not list the sidecar candidate:\n${failure.stderr}`,
+  );
 
-  console.log(`Ferriki packed sidecar verified (${sidecar.filename} resolved by package name, ${main.filename} bundled addon ignored)`)
-}
-finally {
-  await rm(tempRoot, { recursive: true, force: true })
+  console.log(
+    `Ferriki packed sidecar verified (${sidecar.filename} resolved by package name, ${main.filename} bundled addon ignored)`,
+  );
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
 }

--- a/node/scripts/check-platform-package.mjs
+++ b/node/scripts/check-platform-package.mjs
@@ -1,48 +1,51 @@
-import assert from 'node:assert/strict'
-import { spawnSync } from 'node:child_process'
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-const nodeRoot = join(fileURLToPath(new URL('.', import.meta.url)), '..')
-const platformId = process.env.FERRIKI_PLATFORM_ID
-assert(platformId, 'FERRIKI_PLATFORM_ID is required for a platform package check')
+const nodeRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const platformId = process.env.FERRIKI_PLATFORM_ID;
+assert(platformId, "FERRIKI_PLATFORM_ID is required for a platform package check");
 
-const packageDir = join(nodeRoot, 'platforms', platformId)
-const manifest = JSON.parse(await readFile(join(packageDir, 'package.json'), 'utf8'))
-const addon = join(packageDir, 'ferriki.node')
-const info = await stat(addon)
-const npmCache = await mkdtemp(join(tmpdir(), 'ferriki-sidecar-npm-'))
+const packageDir = join(nodeRoot, "platforms", platformId);
+const manifest = JSON.parse(await readFile(join(packageDir, "package.json"), "utf8"));
+const addon = join(packageDir, "ferriki.node");
+const info = await stat(addon);
+const npmCache = await mkdtemp(join(tmpdir(), "ferriki-sidecar-npm-"));
 
-assert.equal(manifest.name, `ferriki-${platformId}`)
-assert(manifest.files.includes('ferriki.node'), `${manifest.name} must publish ferriki.node`)
-for (const licenseFile of ['LICENSE-APACHE', 'LICENSE-MIT'])
-  assert(manifest.files.includes(licenseFile), `${manifest.name} must publish ${licenseFile}`)
-assert(info.size > 100_000, `${manifest.name} native addon is unexpectedly small (${info.size} bytes)`)
+assert.equal(manifest.name, `ferriki-${platformId}`);
+assert(manifest.files.includes("ferriki.node"), `${manifest.name} must publish ferriki.node`);
+for (const licenseFile of ["LICENSE-APACHE", "LICENSE-MIT"])
+  assert(manifest.files.includes(licenseFile), `${manifest.name} must publish ${licenseFile}`);
+assert(
+  info.size > 100_000,
+  `${manifest.name} native addon is unexpectedly small (${info.size} bytes)`,
+);
 
-const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-const packed = spawnSync(npm, ['pack', '--dry-run', '--json'], {
+const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const packed = spawnSync(npm, ["pack", "--dry-run", "--json"], {
   cwd: packageDir,
-  encoding: 'utf8',
+  encoding: "utf8",
   env: {
     ...process.env,
     npm_config_cache: npmCache,
-    npm_config_update_notifier: 'false',
+    npm_config_update_notifier: "false",
   },
-  shell: process.platform === 'win32',
-  stdio: 'pipe',
-})
+  shell: process.platform === "win32",
+  stdio: "pipe",
+});
 if (packed.status !== 0) {
-  await rm(npmCache, { recursive: true, force: true })
-  throw new Error(`${npm} pack failed for ${manifest.name}:\n${packed.stderr}`)
+  await rm(npmCache, { recursive: true, force: true });
+  throw new Error(`${npm} pack failed for ${manifest.name}:\n${packed.stderr}`);
 }
 
-const files = JSON.parse(packed.stdout)[0].files.map(file => file.path)
-assert(files.includes('ferriki.node'), `${manifest.name} dry-run package is missing ferriki.node`)
+const files = JSON.parse(packed.stdout)[0].files.map((file) => file.path);
+assert(files.includes("ferriki.node"), `${manifest.name} dry-run package is missing ferriki.node`);
 // The dual license is only real if both texts travel with the published addon.
-for (const licenseFile of ['LICENSE-APACHE', 'LICENSE-MIT'])
-  assert(files.includes(licenseFile), `${manifest.name} dry-run package is missing ${licenseFile}`)
-await rm(npmCache, { recursive: true, force: true })
-console.log(`Ferriki platform package verified (${manifest.name}, ${info.size} bytes)`)
+for (const licenseFile of ["LICENSE-APACHE", "LICENSE-MIT"])
+  assert(files.includes(licenseFile), `${manifest.name} dry-run package is missing ${licenseFile}`);
+await rm(npmCache, { recursive: true, force: true });
+console.log(`Ferriki platform package verified (${manifest.name}, ${info.size} bytes)`);

--- a/node/scripts/check-release-workflow.mjs
+++ b/node/scripts/check-release-workflow.mjs
@@ -1,52 +1,103 @@
-import assert from 'node:assert/strict'
-import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const nodeRoot = join(fileURLToPath(new URL('.', import.meta.url)), '..')
-const repoRoot = join(nodeRoot, '..')
-const workflow = await readFile(join(repoRoot, '.github/workflows/publish.yml'), 'utf8')
-const checklist = await readFile(join(repoRoot, 'docs/release-checklist.md'), 'utf8')
-const releaseConfig = JSON.parse(await readFile(join(repoRoot, '.release-please-config.json'), 'utf8'))
-const releasePackage = releaseConfig.packages?.['node/ferriki']
-const extraFiles = releasePackage?.['extra-files'] ?? []
+const nodeRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const repoRoot = join(nodeRoot, "..");
+const workflow = await readFile(join(repoRoot, ".github/workflows/publish.yml"), "utf8");
+const checklist = await readFile(join(repoRoot, "docs/release-checklist.md"), "utf8");
+const releaseConfig = JSON.parse(
+  await readFile(join(repoRoot, ".release-please-config.json"), "utf8"),
+);
+const releasePackage = releaseConfig.packages?.["node/ferriki"];
+const extraFiles = releasePackage?.["extra-files"] ?? [];
 
 assert.match(
   workflow,
   /googleapis\/release-please-action@[0-9a-f]{40}/,
-  'release workflow must pin release-please to an immutable commit',
-)
-assert.doesNotMatch(workflow, /uses: [^\n]+@(main|master|v\d)/, 'release workflow must not follow mutable action refs')
-assert.equal(releaseConfig['release-type'], 'node', 'Ferriki release authority must remain the Node package')
-assert.equal(releaseConfig['include-component-in-tag'], false, 'Ferriki must preserve the unscoped product tag format')
-assert.equal(releasePackage?.['changelog-path'], 'CHANGELOG.md', 'release package must declare its changelog path')
+  "release workflow must pin release-please to an immutable commit",
+);
+assert.doesNotMatch(
+  workflow,
+  /uses: [^\n]+@(main|master|v\d)/,
+  "release workflow must not follow mutable action refs",
+);
+assert.equal(
+  releaseConfig["release-type"],
+  "node",
+  "Ferriki release authority must remain the Node package",
+);
+assert.equal(
+  releaseConfig["include-component-in-tag"],
+  false,
+  "Ferriki must preserve the unscoped product tag format",
+);
+assert.equal(
+  releasePackage?.["changelog-path"],
+  "CHANGELOG.md",
+  "release package must declare its changelog path",
+);
 assert(
-  extraFiles.some(file => file.path === '/node/ferriki/package.json' && file.jsonpath === '$.optionalDependencies[*]'),
-  'release config must update all platform dependency versions with the product version',
-)
+  extraFiles.some(
+    (file) =>
+      file.path === "/node/ferriki/package.json" && file.jsonpath === "$.optionalDependencies[*]",
+  ),
+  "release config must update all platform dependency versions with the product version",
+);
 assert(
-  extraFiles.some(file => file.path === '/node/platforms/*/package.json' && file.glob === true && file.jsonpath === '$.version'),
-  'release config must update every platform package manifest with the product version',
-)
+  extraFiles.some(
+    (file) =>
+      file.path === "/node/platforms/*/package.json" &&
+      file.glob === true &&
+      file.jsonpath === "$.version",
+  ),
+  "release config must update every platform package manifest with the product version",
+);
 assert(
-  extraFiles.some(file => file.path === '/node/pnpm-lock.yaml' && file.type === 'yaml' && file.jsonpath === '$.importers.ferriki.optionalDependencies[*].specifier'),
-  'release config must update the pnpm lockfile dependency specifiers',
-)
-assert.doesNotMatch(workflow, /sync:platform-versions/, 'release workflow must not patch generated release candidates')
-for (const job of ['release-please:', 'build-native:', 'publish-npm:', 'verify-npm-publish:', 'release-summary:'])
-  assert(workflow.includes(`  ${job}`), `release workflow is missing ${job}`)
-for (const required of [
-  'force-publish:',
-  'dist-tag:',
-  'timeout-minutes:',
-  'actions/download-artifact@',
-  'npm publish --access public --provenance',
-  'NPM_PUBLISH_RESULT:',
-  'write-release-summary.mjs',
+  extraFiles.some(
+    (file) =>
+      file.path === "/node/pnpm-lock.yaml" &&
+      file.type === "yaml" &&
+      file.jsonpath === "$.importers.ferriki.optionalDependencies[*].specifier",
+  ),
+  "release config must update the pnpm lockfile dependency specifiers",
+);
+assert.doesNotMatch(
+  workflow,
+  /sync:platform-versions/,
+  "release workflow must not patch generated release candidates",
+);
+for (const job of [
+  "release-please:",
+  "build-native:",
+  "publish-npm:",
+  "verify-npm-publish:",
+  "release-summary:",
 ])
-  assert(workflow.includes(required), `release workflow is missing ${required}`)
+  assert(workflow.includes(`  ${job}`), `release workflow is missing ${job}`);
+for (const required of [
+  "force-publish:",
+  "dist-tag:",
+  "timeout-minutes:",
+  "actions/download-artifact@",
+  "npm publish --access public --provenance",
+  "NPM_PUBLISH_RESULT:",
+  "write-release-summary.mjs",
+])
+  assert(workflow.includes(required), `release workflow is missing ${required}`);
 
-for (const required of ['npm provenance', 'GitHub release', 'tarball', 'rollback', 'deprecate', 'go/no-go'])
-  assert(checklist.toLowerCase().includes(required.toLowerCase()), `release checklist is missing ${required}`)
+for (const required of [
+  "npm provenance",
+  "GitHub release",
+  "tarball",
+  "rollback",
+  "deprecate",
+  "go/no-go",
+])
+  assert(
+    checklist.toLowerCase().includes(required.toLowerCase()),
+    `release checklist is missing ${required}`,
+  );
 
-console.log('Ferriki release workflow and checklist verified')
+console.log("Ferriki release workflow and checklist verified");

--- a/node/scripts/check-shiki-compat-clean.mjs
+++ b/node/scripts/check-shiki-compat-clean.mjs
@@ -1,23 +1,24 @@
-import { spawnSync } from 'node:child_process'
-import process from 'node:process'
+import { spawnSync } from "node:child_process";
+import process from "node:process";
 
-const mirrorPath = 'compat/upstream/shiki'
+const mirrorPath = "compat/upstream/shiki";
 
 function checkGit(args) {
-  const result = spawnSync('git', args, {
+  const result = spawnSync("git", args, {
     cwd: process.cwd(),
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  })
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
 
-  if (result.status === 0)
-    return
+  if (result.status === 0) return;
 
-  const details = `${result.stdout || ''}${result.stderr || ''}`.trim()
-  console.error(`[check-shiki-compat-clean] compatibility mirror is dirty${details ? `:\n${details}` : ''}`)
-  process.exit(result.status || 1)
+  const details = `${result.stdout || ""}${result.stderr || ""}`.trim();
+  console.error(
+    `[check-shiki-compat-clean] compatibility mirror is dirty${details ? `:\n${details}` : ""}`,
+  );
+  process.exit(result.status || 1);
 }
 
-checkGit(['diff', '--quiet', '--', mirrorPath])
-checkGit(['diff', '--cached', '--quiet', '--', mirrorPath])
-console.log('[check-shiki-compat-clean] compatibility mirror is clean')
+checkGit(["diff", "--quiet", "--", mirrorPath]);
+checkGit(["diff", "--cached", "--quiet", "--", mirrorPath]);
+console.log("[check-shiki-compat-clean] compatibility mirror is clean");

--- a/node/scripts/check-shiki-compat-manifest.mjs
+++ b/node/scripts/check-shiki-compat-manifest.mjs
@@ -1,62 +1,58 @@
-import { spawnSync } from 'node:child_process'
-import { createHash } from 'node:crypto'
-import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
-import process from 'node:process'
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import process from "node:process";
 
-const repoRoot = new URL('../..', import.meta.url).pathname
-const mirrorRoot = join(repoRoot, 'node', 'compat', 'upstream', 'shiki')
-const metadataPath = join(mirrorRoot, '.source.json')
+const repoRoot = new URL("../..", import.meta.url).pathname;
+const mirrorRoot = join(repoRoot, "node", "compat", "upstream", "shiki");
+const metadataPath = join(mirrorRoot, ".source.json");
 
 function fail(message) {
-  console.error(`[check-shiki-compat-manifest] ${message}`)
-  process.exit(1)
+  console.error(`[check-shiki-compat-manifest] ${message}`);
+  process.exit(1);
 }
 
-const metadata = JSON.parse(await readFile(metadataPath, 'utf8'))
-if (metadata.manifest !== '.manifest.sha256')
-  fail('mirror metadata must point to .manifest.sha256')
-if (!/^[a-f0-9]{64}$/.test(metadata.manifestSha256 || ''))
-  fail('mirror metadata must contain a SHA-256 for the manifest')
+const metadata = JSON.parse(await readFile(metadataPath, "utf8"));
+if (metadata.manifest !== ".manifest.sha256")
+  fail("mirror metadata must point to .manifest.sha256");
+if (!/^[a-f0-9]{64}$/.test(metadata.manifestSha256 || ""))
+  fail("mirror metadata must contain a SHA-256 for the manifest");
 
-const manifestPath = join(mirrorRoot, metadata.manifest)
-const manifest = await readFile(manifestPath, 'utf8')
-const actualManifestHash = createHash('sha256').update(manifest).digest('hex')
+const manifestPath = join(mirrorRoot, metadata.manifest);
+const manifest = await readFile(manifestPath, "utf8");
+const actualManifestHash = createHash("sha256").update(manifest).digest("hex");
 if (actualManifestHash !== metadata.manifestSha256)
-  fail('manifest checksum does not match mirror metadata')
+  fail("manifest checksum does not match mirror metadata");
 
 const entries = manifest
   .trimEnd()
-  .split('\n')
+  .split("\n")
   .filter(Boolean)
   .map((line) => {
-    const match = line.match(/^([a-f0-9]{64})\s{2}(.+)$/)
-    if (!match)
-      fail(`invalid manifest line: ${line}`)
-    return { digest: match[1], path: match[2] }
-  })
+    const match = line.match(/^([a-f0-9]{64})\s{2}(.+)$/);
+    if (!match) fail(`invalid manifest line: ${line}`);
+    return { digest: match[1], path: match[2] };
+  });
 
-const listed = new Set()
+const listed = new Set();
 for (const entry of entries) {
-  if (listed.has(entry.path))
-    fail(`duplicate manifest path: ${entry.path}`)
-  listed.add(entry.path)
-  const bytes = await readFile(join(mirrorRoot, entry.path))
-  const digest = createHash('sha256').update(bytes).digest('hex')
-  if (digest !== entry.digest)
-    fail(`checksum mismatch: ${entry.path}`)
+  if (listed.has(entry.path)) fail(`duplicate manifest path: ${entry.path}`);
+  listed.add(entry.path);
+  const bytes = await readFile(join(mirrorRoot, entry.path));
+  const digest = createHash("sha256").update(bytes).digest("hex");
+  if (digest !== entry.digest) fail(`checksum mismatch: ${entry.path}`);
 }
 
-const result = spawnSync('git', ['-C', mirrorRoot, 'ls-files'], { encoding: 'utf8' })
-if (result.status !== 0)
-  fail(result.stderr || 'Unable to list the Shiki compatibility mirror')
+const result = spawnSync("git", ["-C", mirrorRoot, "ls-files"], { encoding: "utf8" });
+if (result.status !== 0) fail(result.stderr || "Unable to list the Shiki compatibility mirror");
 const tracked = result.stdout
-  .split('\n')
-  .map(path => path.trim())
-  .filter(path => path && path !== '.source.json' && path !== '.manifest.sha256')
-  .sort()
-const expected = [...listed].sort()
+  .split("\n")
+  .map((path) => path.trim())
+  .filter((path) => path && path !== ".source.json" && path !== ".manifest.sha256")
+  .sort();
+const expected = [...listed].sort();
 if (tracked.length !== expected.length || tracked.some((path, index) => path !== expected[index]))
-  fail('manifest paths do not match the tracked mirror files')
+  fail("manifest paths do not match the tracked mirror files");
 
-console.log(`[check-shiki-compat-manifest] verified ${entries.length} file checksums`)
+console.log(`[check-shiki-compat-manifest] verified ${entries.length} file checksums`);

--- a/node/scripts/generate-shiki-compat-manifest.mjs
+++ b/node/scripts/generate-shiki-compat-manifest.mjs
@@ -1,36 +1,36 @@
-import { spawnSync } from 'node:child_process'
-import { createHash } from 'node:crypto'
-import { readFile, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 
-const repoRoot = new URL('../..', import.meta.url).pathname
-const mirrorRoot = join(repoRoot, 'node', 'compat', 'upstream', 'shiki')
-const metadataPath = join(mirrorRoot, '.source.json')
-const manifestPath = join(mirrorRoot, '.manifest.sha256')
+const repoRoot = new URL("../..", import.meta.url).pathname;
+const mirrorRoot = join(repoRoot, "node", "compat", "upstream", "shiki");
+const metadataPath = join(mirrorRoot, ".source.json");
+const manifestPath = join(mirrorRoot, ".manifest.sha256");
 
-const result = spawnSync('git', ['-C', mirrorRoot, 'ls-files'], { encoding: 'utf8' })
+const result = spawnSync("git", ["-C", mirrorRoot, "ls-files"], { encoding: "utf8" });
 if (result.status !== 0)
-  throw new Error(result.stderr || 'Unable to list the Shiki compatibility mirror')
+  throw new Error(result.stderr || "Unable to list the Shiki compatibility mirror");
 
 const paths = result.stdout
-  .split('\n')
-  .map(path => path.trim())
-  .filter(path => path && path !== '.source.json' && path !== '.manifest.sha256')
-  .sort()
+  .split("\n")
+  .map((path) => path.trim())
+  .filter((path) => path && path !== ".source.json" && path !== ".manifest.sha256")
+  .sort();
 
-const lines = []
+const lines = [];
 for (const relativePath of paths) {
-  const bytes = await readFile(join(mirrorRoot, relativePath))
-  const digest = createHash('sha256').update(bytes).digest('hex')
-  lines.push(`${digest}  ${relativePath}`)
+  const bytes = await readFile(join(mirrorRoot, relativePath));
+  const digest = createHash("sha256").update(bytes).digest("hex");
+  lines.push(`${digest}  ${relativePath}`);
 }
 
-const manifest = `${lines.join('\n')}\n`
-await writeFile(manifestPath, manifest, 'utf8')
+const manifest = `${lines.join("\n")}\n`;
+await writeFile(manifestPath, manifest, "utf8");
 
-const metadata = JSON.parse(await readFile(metadataPath, 'utf8'))
-metadata.manifest = '.manifest.sha256'
-metadata.manifestSha256 = createHash('sha256').update(manifest).digest('hex')
-await writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf8')
+const metadata = JSON.parse(await readFile(metadataPath, "utf8"));
+metadata.manifest = ".manifest.sha256";
+metadata.manifestSha256 = createHash("sha256").update(manifest).digest("hex");
+await writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
 
-console.log(`[generate-shiki-compat-manifest] wrote ${paths.length} file checksums`)
+console.log(`[generate-shiki-compat-manifest] wrote ${paths.length} file checksums`);

--- a/node/scripts/prepare-shiki-compat.mjs
+++ b/node/scripts/prepare-shiki-compat.mjs
@@ -1,90 +1,104 @@
-import { spawnSync } from 'node:child_process'
-import { cp, mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
-import os from 'node:os'
-import path from 'node:path'
-import process from 'node:process'
+import { spawnSync } from "node:child_process";
+import { cp, mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
 
-const scriptDir = path.dirname(new URL(import.meta.url).pathname)
-const nodeRoot = path.resolve(scriptDir, '..')
-const mirrorRoot = path.join(nodeRoot, 'compat/upstream/shiki')
-const checkScript = path.join(scriptDir, 'check-shiki-compat-clean.mjs')
-const manifestCheckScript = path.join(scriptDir, 'check-shiki-compat-manifest.mjs')
+const scriptDir = path.dirname(new URL(import.meta.url).pathname);
+const nodeRoot = path.resolve(scriptDir, "..");
+const mirrorRoot = path.join(nodeRoot, "compat/upstream/shiki");
+const checkScript = path.join(scriptDir, "check-shiki-compat-clean.mjs");
+const manifestCheckScript = path.join(scriptDir, "check-shiki-compat-manifest.mjs");
 
 function run(command, args, cwd) {
   const result = spawnSync(command, args, {
     cwd,
-    stdio: 'inherit',
+    stdio: "inherit",
     env: process.env,
-  })
+  });
 
-  if (result.status !== 0)
-    process.exit(result.status || 1)
+  if (result.status !== 0) process.exit(result.status || 1);
 }
 
 function packagePath(name) {
-  return path.join(mirrorRoot, 'packages', name)
+  return path.join(mirrorRoot, "packages", name);
 }
 
 async function prepareIn(directory) {
-  run(process.execPath, ['--import', 'tsx/esm', path.join(directory, 'scripts/prepare.ts')], directory)
+  run(
+    process.execPath,
+    ["--import", "tsx/esm", path.join(directory, "scripts/prepare.ts")],
+    directory,
+  );
 }
 
 async function copyPackage(source, destination) {
   await cp(source, destination, {
     recursive: true,
     filter(sourcePath) {
-      const relative = path.relative(source, sourcePath)
-      return relative !== 'node_modules'
-        && relative !== 'dist'
-        && !relative.startsWith(`node_modules${path.sep}`)
-        && !relative.startsWith(`dist${path.sep}`)
+      const relative = path.relative(source, sourcePath);
+      return (
+        relative !== "node_modules" &&
+        relative !== "dist" &&
+        !relative.startsWith(`node_modules${path.sep}`) &&
+        !relative.startsWith(`dist${path.sep}`)
+      );
     },
-  })
+  });
 }
 
 async function main() {
-  run(process.execPath, [manifestCheckScript], nodeRoot)
-  run(process.execPath, [checkScript], nodeRoot)
+  run(process.execPath, [manifestCheckScript], nodeRoot);
+  run(process.execPath, [checkScript], nodeRoot);
 
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'ferriki-shiki-'))
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "ferriki-shiki-"));
   try {
-    const tempPackages = path.join(tempRoot, 'packages')
-    await mkdir(tempPackages, { recursive: true })
-    await symlink(path.join(nodeRoot, 'node_modules'), path.join(tempRoot, 'node_modules'))
+    const tempPackages = path.join(tempRoot, "packages");
+    await mkdir(tempPackages, { recursive: true });
+    await symlink(path.join(nodeRoot, "node_modules"), path.join(tempRoot, "node_modules"));
 
-    const tempLangs = path.join(tempPackages, 'langs')
-    const tempThemes = path.join(tempPackages, 'themes')
-    const tempShiki = path.join(tempPackages, 'shiki')
-    await copyPackage(packagePath('langs'), tempLangs)
-    await copyPackage(packagePath('themes'), tempThemes)
-    await copyPackage(packagePath('shiki'), tempShiki)
+    const tempLangs = path.join(tempPackages, "langs");
+    const tempThemes = path.join(tempPackages, "themes");
+    const tempShiki = path.join(tempPackages, "shiki");
+    await copyPackage(packagePath("langs"), tempLangs);
+    await copyPackage(packagePath("themes"), tempThemes);
+    await copyPackage(packagePath("shiki"), tempShiki);
 
     // The upstream generators intentionally rewrite package.json and Shiki's
     // bundle indexes. Run them in a throw-away checkout and keep only dist/.
-    await symlink(path.join(packagePath('langs'), 'node_modules'), path.join(tempLangs, 'node_modules'))
-    await symlink(path.join(packagePath('themes'), 'node_modules'), path.join(tempThemes, 'node_modules'))
-    await prepareIn(tempLangs)
-    await prepareIn(tempThemes)
+    await symlink(
+      path.join(packagePath("langs"), "node_modules"),
+      path.join(tempLangs, "node_modules"),
+    );
+    await symlink(
+      path.join(packagePath("themes"), "node_modules"),
+      path.join(tempThemes, "node_modules"),
+    );
+    await prepareIn(tempLangs);
+    await prepareIn(tempThemes);
 
-    await rm(path.join(packagePath('langs'), 'dist'), { recursive: true, force: true })
-    await rm(path.join(packagePath('themes'), 'dist'), { recursive: true, force: true })
-    await cp(path.join(tempLangs, 'dist'), path.join(packagePath('langs'), 'dist'), { recursive: true })
-    await cp(path.join(tempThemes, 'dist'), path.join(packagePath('themes'), 'dist'), { recursive: true })
+    await rm(path.join(packagePath("langs"), "dist"), { recursive: true, force: true });
+    await rm(path.join(packagePath("themes"), "dist"), { recursive: true, force: true });
+    await cp(path.join(tempLangs, "dist"), path.join(packagePath("langs"), "dist"), {
+      recursive: true,
+    });
+    await cp(path.join(tempThemes, "dist"), path.join(packagePath("themes"), "dist"), {
+      recursive: true,
+    });
 
     // These generators only write ignored files in the real mirror and are
     // needed by the package builds and compatibility tests.
-    await prepareIn(packagePath('shiki'))
-    await prepareIn(packagePath('colorized-brackets'))
-  }
-  finally {
-    await rm(tempRoot, { recursive: true, force: true })
+    await prepareIn(packagePath("shiki"));
+    await prepareIn(packagePath("colorized-brackets"));
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
   }
 
-  run(process.execPath, [checkScript], nodeRoot)
-  run(process.execPath, [manifestCheckScript], nodeRoot)
+  run(process.execPath, [checkScript], nodeRoot);
+  run(process.execPath, [manifestCheckScript], nodeRoot);
 }
 
 main().catch((error) => {
-  console.error(`[prepare-shiki-compat] ${error.stack || error}`)
-  process.exit(1)
-})
+  console.error(`[prepare-shiki-compat] ${error.stack || error}`);
+  process.exit(1);
+});

--- a/node/scripts/run-core-compat.mjs
+++ b/node/scripts/run-core-compat.mjs
@@ -1,237 +1,228 @@
-import { spawnSync } from 'node:child_process'
-import path from 'node:path'
-import process from 'node:process'
-import { fileURLToPath } from 'node:url'
-import { coreCompatDeferredTests, coreCompatSupportedTests } from '../compat/harness/core-compat-manifest.mjs'
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import {
+  coreCompatDeferredTests,
+  coreCompatSupportedTests,
+} from "../compat/harness/core-compat-manifest.mjs";
 
-const nodeRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
-const vitestArgs = [
-  'exec',
-  'vitest',
-]
-const testNamePattern = '^(should|langAlias|getSingletonHighlighter|vue-injections|injections-side-effects|bundle-(full|web))'
+const nodeRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const vitestArgs = ["exec", "vitest"];
+const testNamePattern =
+  "^(should|langAlias|getSingletonHighlighter|vue-injections|injections-side-effects|bundle-(full|web))";
 
-const catalogCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-catalog.mjs'], {
+const catalogCheck = spawnSync(process.execPath, ["./scripts/check-ferriki-catalog.mjs"], {
   cwd: nodeRoot,
   env: {
     ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
+    FERRIKI_HONEST_ALIAS: "1",
   },
-  stdio: 'inherit',
-})
-if (catalogCheck.status !== 0)
-  process.exit(catalogCheck.status || 1)
+  stdio: "inherit",
+});
+if (catalogCheck.status !== 0) process.exit(catalogCheck.status || 1);
 
-const exportCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-exports.mjs'], {
+const exportCheck = spawnSync(process.execPath, ["./scripts/check-ferriki-exports.mjs"], {
   cwd: nodeRoot,
   env: {
     ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
+    FERRIKI_HONEST_ALIAS: "1",
   },
-  stdio: 'inherit',
-})
-if (exportCheck.status !== 0)
-  process.exit(exportCheck.status || 1)
+  stdio: "inherit",
+});
+if (exportCheck.status !== 0) process.exit(exportCheck.status || 1);
 
-const apiContractCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-api-contract.mjs'], {
+const apiContractCheck = spawnSync(process.execPath, ["./scripts/check-ferriki-api-contract.mjs"], {
   cwd: nodeRoot,
   env: {
     ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
+    FERRIKI_HONEST_ALIAS: "1",
   },
-  stdio: 'inherit',
-})
-if (apiContractCheck.status !== 0)
-  process.exit(apiContractCheck.status || 1)
+  stdio: "inherit",
+});
+if (apiContractCheck.status !== 0) process.exit(apiContractCheck.status || 1);
 
-const nativeBoundaryCheck = spawnSync(process.execPath, ['./scripts/check-native-boundary.mjs'], {
+const nativeBoundaryCheck = spawnSync(process.execPath, ["./scripts/check-native-boundary.mjs"], {
   cwd: nodeRoot,
   env: {
     ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
+    FERRIKI_HONEST_ALIAS: "1",
   },
-  stdio: 'inherit',
-})
-if (nativeBoundaryCheck.status !== 0)
-  process.exit(nativeBoundaryCheck.status || 1)
+  stdio: "inherit",
+});
+if (nativeBoundaryCheck.status !== 0) process.exit(nativeBoundaryCheck.status || 1);
 
-const releaseCheck = spawnSync(process.execPath, ['./scripts/check-release-workflow.mjs'], {
+const releaseCheck = spawnSync(process.execPath, ["./scripts/check-release-workflow.mjs"], {
   cwd: nodeRoot,
   env: {
     ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
+    FERRIKI_HONEST_ALIAS: "1",
   },
-  stdio: 'inherit',
-})
-if (releaseCheck.status !== 0)
-  process.exit(releaseCheck.status || 1)
+  stdio: "inherit",
+});
+if (releaseCheck.status !== 0) process.exit(releaseCheck.status || 1);
 
-const docsCheck = spawnSync(process.execPath, ['./scripts/check-docs-drift.mjs'], {
+const docsCheck = spawnSync(process.execPath, ["./scripts/check-docs-drift.mjs"], {
   cwd: nodeRoot,
   env: {
     ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
+    FERRIKI_HONEST_ALIAS: "1",
   },
-  stdio: 'inherit',
-})
-if (docsCheck.status !== 0)
-  process.exit(docsCheck.status || 1)
+  stdio: "inherit",
+});
+if (docsCheck.status !== 0) process.exit(docsCheck.status || 1);
 
-const docsDriftTest = spawnSync(process.execPath, ['./scripts/test-docs-drift.mjs'], {
+const docsDriftTest = spawnSync(process.execPath, ["./scripts/test-docs-drift.mjs"], {
   cwd: nodeRoot,
   env: {
     ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
+    FERRIKI_HONEST_ALIAS: "1",
   },
-  stdio: 'inherit',
-})
-if (docsDriftTest.status !== 0)
-  process.exit(docsDriftTest.status || 1)
+  stdio: "inherit",
+});
+if (docsDriftTest.status !== 0) process.exit(docsDriftTest.status || 1);
 
-const docsContractCheck = spawnSync(process.execPath, ['./scripts/check-docs-contract.mjs'], {
+const docsContractCheck = spawnSync(process.execPath, ["./scripts/check-docs-contract.mjs"], {
   cwd: nodeRoot,
   env: {
     ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
+    FERRIKI_HONEST_ALIAS: "1",
   },
-  stdio: 'inherit',
-})
-if (docsContractCheck.status !== 0)
-  process.exit(docsContractCheck.status || 1)
+  stdio: "inherit",
+});
+if (docsContractCheck.status !== 0) process.exit(docsContractCheck.status || 1);
 
-const packedConsumerCheck = spawnSync(process.execPath, ['./scripts/check-packed-consumer.mjs'], {
+const packedConsumerCheck = spawnSync(process.execPath, ["./scripts/check-packed-consumer.mjs"], {
   cwd: nodeRoot,
   env: {
     ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
+    FERRIKI_HONEST_ALIAS: "1",
   },
-  stdio: 'inherit',
-})
-if (packedConsumerCheck.status !== 0)
-  process.exit(packedConsumerCheck.status || 1)
+  stdio: "inherit",
+});
+if (packedConsumerCheck.status !== 0) process.exit(packedConsumerCheck.status || 1);
 
-const errorCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-errors.mjs'], {
+const errorCheck = spawnSync(process.execPath, ["./scripts/check-ferriki-errors.mjs"], {
   cwd: nodeRoot,
   env: {
     ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
+    FERRIKI_HONEST_ALIAS: "1",
   },
-  stdio: 'inherit',
-})
-if (errorCheck.status !== 0)
-  process.exit(errorCheck.status || 1)
+  stdio: "inherit",
+});
+if (errorCheck.status !== 0) process.exit(errorCheck.status || 1);
 
-const multiThemeCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-multitheme.mjs'], {
+const multiThemeCheck = spawnSync(process.execPath, ["./scripts/check-ferriki-multitheme.mjs"], {
   cwd: nodeRoot,
   env: {
     ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
+    FERRIKI_HONEST_ALIAS: "1",
   },
-  stdio: 'inherit',
-})
-if (multiThemeCheck.status !== 0)
-  process.exit(multiThemeCheck.status || 1)
+  stdio: "inherit",
+});
+if (multiThemeCheck.status !== 0) process.exit(multiThemeCheck.status || 1);
 
-const ansiCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-ansi.mjs'], {
+const ansiCheck = spawnSync(process.execPath, ["./scripts/check-ferriki-ansi.mjs"], {
   cwd: nodeRoot,
   env: {
     ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
+    FERRIKI_HONEST_ALIAS: "1",
   },
-  stdio: 'inherit',
-})
-if (ansiCheck.status !== 0)
-  process.exit(ansiCheck.status || 1)
+  stdio: "inherit",
+});
+if (ansiCheck.status !== 0) process.exit(ansiCheck.status || 1);
 
-const registrationCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-registrations.mjs'], {
-  cwd: nodeRoot,
-  env: {
-    ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
-  },
-  stdio: 'inherit',
-})
-if (registrationCheck.status !== 0)
-  process.exit(registrationCheck.status || 1)
-
-const transformerCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-transformers.mjs'], {
-  cwd: nodeRoot,
-  env: {
-    ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
-  },
-  stdio: 'inherit',
-})
-if (transformerCheck.status !== 0)
-  process.exit(transformerCheck.status || 1)
-
-const tokenStateCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-token-state.mjs'], {
-  cwd: nodeRoot,
-  env: {
-    ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
-  },
-  stdio: 'inherit',
-})
-if (tokenStateCheck.status !== 0)
-  process.exit(tokenStateCheck.status || 1)
-
-const ferromarkArdoCheck = spawnSync(process.execPath, ['./scripts/check-ferromark-ardo-contract.mjs'], {
-  cwd: nodeRoot,
-  env: {
-    ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
-  },
-  stdio: 'inherit',
-})
-if (ferromarkArdoCheck.status !== 0)
-  process.exit(ferromarkArdoCheck.status || 1)
-
-const platformMatrixCheck = spawnSync(process.execPath, ['./scripts/check-ferriki-platform-matrix.mjs'], {
-  cwd: nodeRoot,
-  env: {
-    ...process.env,
-    FERRIKI_HONEST_ALIAS: '1',
-  },
-  stdio: 'inherit',
-})
-if (platformMatrixCheck.status !== 0)
-  process.exit(platformMatrixCheck.status || 1)
-
-function run(args) {
-  const result = spawnSync('pnpm', [...vitestArgs, ...args], {
+const registrationCheck = spawnSync(
+  process.execPath,
+  ["./scripts/check-ferriki-registrations.mjs"],
+  {
     cwd: nodeRoot,
     env: {
       ...process.env,
-      FERRIKI_HONEST_ALIAS: '1',
+      FERRIKI_HONEST_ALIAS: "1",
     },
-    stdio: 'inherit',
-  })
+    stdio: "inherit",
+  },
+);
+if (registrationCheck.status !== 0) process.exit(registrationCheck.status || 1);
 
-  if (result.status !== 0)
-    process.exit(result.status || 1)
+const transformerCheck = spawnSync(process.execPath, ["./scripts/check-ferriki-transformers.mjs"], {
+  cwd: nodeRoot,
+  env: {
+    ...process.env,
+    FERRIKI_HONEST_ALIAS: "1",
+  },
+  stdio: "inherit",
+});
+if (transformerCheck.status !== 0) process.exit(transformerCheck.status || 1);
+
+const tokenStateCheck = spawnSync(process.execPath, ["./scripts/check-ferriki-token-state.mjs"], {
+  cwd: nodeRoot,
+  env: {
+    ...process.env,
+    FERRIKI_HONEST_ALIAS: "1",
+  },
+  stdio: "inherit",
+});
+if (tokenStateCheck.status !== 0) process.exit(tokenStateCheck.status || 1);
+
+const ferromarkArdoCheck = spawnSync(
+  process.execPath,
+  ["./scripts/check-ferromark-ardo-contract.mjs"],
+  {
+    cwd: nodeRoot,
+    env: {
+      ...process.env,
+      FERRIKI_HONEST_ALIAS: "1",
+    },
+    stdio: "inherit",
+  },
+);
+if (ferromarkArdoCheck.status !== 0) process.exit(ferromarkArdoCheck.status || 1);
+
+const platformMatrixCheck = spawnSync(
+  process.execPath,
+  ["./scripts/check-ferriki-platform-matrix.mjs"],
+  {
+    cwd: nodeRoot,
+    env: {
+      ...process.env,
+      FERRIKI_HONEST_ALIAS: "1",
+    },
+    stdio: "inherit",
+  },
+);
+if (platformMatrixCheck.status !== 0) process.exit(platformMatrixCheck.status || 1);
+
+function run(args) {
+  const result = spawnSync("pnpm", [...vitestArgs, ...args], {
+    cwd: nodeRoot,
+    env: {
+      ...process.env,
+      FERRIKI_HONEST_ALIAS: "1",
+    },
+    stdio: "inherit",
+  });
+
+  if (result.status !== 0) process.exit(result.status || 1);
 }
 
-run([
-  'run',
-  'compat/harness/honest-alias.test.ts',
-  '--maxWorkers',
-  '1',
-  '--no-file-parallelism',
-])
+run(["run", "compat/harness/honest-alias.test.ts", "--maxWorkers", "1", "--no-file-parallelism"]);
 
 run([
-  'run',
+  "run",
   ...coreCompatSupportedTests,
-  '-t',
+  "-t",
   testNamePattern,
-  '--maxWorkers',
-  '1',
-  '--no-file-parallelism',
-])
+  "--maxWorkers",
+  "1",
+  "--no-file-parallelism",
+]);
 
-console.log('\nFerriki core compatibility summary')
-console.log(`- supported contracts: ${coreCompatSupportedTests.length} test files (mandatory)`)
-console.log(`- deferred contracts: ${coreCompatDeferredTests.length} test files (each linked to its owning issue)`)
+console.log("\nFerriki core compatibility summary");
+console.log(`- supported contracts: ${coreCompatSupportedTests.length} test files (mandatory)`);
+console.log(
+  `- deferred contracts: ${coreCompatDeferredTests.length} test files (each linked to its owning issue)`,
+);
 for (const test of coreCompatDeferredTests)
-  console.log(`  - ${test.path}: ${test.reason} (see #${test.issue})`)
+  console.log(`  - ${test.path}: ${test.reason} (see #${test.issue})`);

--- a/node/scripts/sync-shiki-compat.mjs
+++ b/node/scripts/sync-shiki-compat.mjs
@@ -1,64 +1,56 @@
-import { Buffer } from 'node:buffer'
-import { spawnSync } from 'node:child_process'
-import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
-import path from 'node:path'
-import process from 'node:process'
+import { Buffer } from "node:buffer";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
 
-const CONTROL_FILES = new Set(['.source.json'])
+const CONTROL_FILES = new Set([".source.json"]);
 
 function fail(message) {
-  console.error(`[sync-shiki-compat] ${message}`)
-  process.exit(1)
+  console.error(`[sync-shiki-compat] ${message}`);
+  process.exit(1);
 }
 
 function runGit(cwd, args, options = {}) {
-  const result = spawnSync('git', args, {
+  const result = spawnSync("git", args, {
     cwd,
-    encoding: options.encoding ?? 'buffer',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  })
+    encoding: options.encoding ?? "buffer",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
 
   if (result.status !== 0) {
     const stderr = Buffer.isBuffer(result.stderr)
-      ? result.stderr.toString('utf8').trim()
-      : String(result.stderr || '').trim()
-    fail(`git ${args.join(' ')} failed${stderr ? `: ${stderr}` : ''}`)
+      ? result.stderr.toString("utf8").trim()
+      : String(result.stderr || "").trim();
+    fail(`git ${args.join(" ")} failed${stderr ? `: ${stderr}` : ""}`);
   }
 
-  return result.stdout
+  return result.stdout;
 }
 
 function parseArgs(argv) {
   const args = {
     sourceRepo: process.cwd(),
-    targetDir: path.join(process.cwd(), 'compat/upstream/shiki'),
-    pathsFile: path.join(process.cwd(), 'compat/upstream/shiki-paths.json'),
+    targetDir: path.join(process.cwd(), "compat/upstream/shiki"),
+    pathsFile: path.join(process.cwd(), "compat/upstream/shiki-paths.json"),
     check: false,
     dryRun: false,
-    ref: '',
-  }
+    ref: "",
+  };
 
   for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index]
-    if (arg === '--source-repo')
-      args.sourceRepo = path.resolve(argv[++index] || '')
-    else if (arg === '--target-dir')
-      args.targetDir = path.resolve(argv[++index] || '')
-    else if (arg === '--paths-file')
-      args.pathsFile = path.resolve(argv[++index] || '')
-    else if (arg === '--ref')
-      args.ref = argv[++index] || ''
-    else if (arg === '--check')
-      args.check = true
-    else if (arg === '--dry-run')
-      args.dryRun = true
-    else if (arg === '--help')
-      args.help = true
-    else
-      fail(`unknown argument: ${arg}`)
+    const arg = argv[index];
+    if (arg === "--source-repo") args.sourceRepo = path.resolve(argv[++index] || "");
+    else if (arg === "--target-dir") args.targetDir = path.resolve(argv[++index] || "");
+    else if (arg === "--paths-file") args.pathsFile = path.resolve(argv[++index] || "");
+    else if (arg === "--ref") args.ref = argv[++index] || "";
+    else if (arg === "--check") args.check = true;
+    else if (arg === "--dry-run") args.dryRun = true;
+    else if (arg === "--help") args.help = true;
+    else fail(`unknown argument: ${arg}`);
   }
 
-  return args
+  return args;
 }
 
 function printHelp() {
@@ -72,169 +64,169 @@ Options:
   --check               Verify the existing mirror matches the source ref
   --dry-run             Print the import plan without writing files
   --help                Show this help
-`)
+`);
 }
 
 function loadMirrorPaths(pathsFile) {
-  const raw = JSON.parse(readFileSync(pathsFile, 'utf8'))
+  const raw = JSON.parse(readFileSync(pathsFile, "utf8"));
   if (!Array.isArray(raw) || raw.length === 0)
-    fail(`paths file must be a non-empty JSON array: ${pathsFile}`)
+    fail(`paths file must be a non-empty JSON array: ${pathsFile}`);
 
   return raw.map((entry) => {
-    if (typeof entry !== 'string' || !entry.trim())
-      fail(`invalid path entry in ${pathsFile}`)
-    return entry.replace(/\\/g, '/').replace(/\/+$/, '')
-  })
+    if (typeof entry !== "string" || !entry.trim()) fail(`invalid path entry in ${pathsFile}`);
+    return entry.replace(/\\/g, "/").replace(/\/+$/, "");
+  });
 }
 
 function resolveRef(sourceRepo, ref, metadataPath, checkMode) {
-  if (ref)
-    return ref
+  if (ref) return ref;
 
-  if (!checkMode)
-    fail('missing required --ref')
+  if (!checkMode) fail("missing required --ref");
 
-  const metadata = JSON.parse(readFileSync(metadataPath, 'utf8'))
-  if (typeof metadata.ref !== 'string' || !metadata.ref)
-    fail(`mirror metadata does not contain a ref: ${metadataPath}`)
-  return metadata.ref
+  const metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
+  if (typeof metadata.ref !== "string" || !metadata.ref)
+    fail(`mirror metadata does not contain a ref: ${metadataPath}`);
+  return metadata.ref;
 }
 
 function listFilesAtRef(sourceRepo, ref, mirrorPaths) {
-  const files = new Set()
+  const files = new Set();
 
   for (const mirrorPath of mirrorPaths) {
-    const stdout = runGit(sourceRepo, ['ls-tree', '-r', '--name-only', ref, '--', mirrorPath], { encoding: 'utf8' })
+    const stdout = runGit(sourceRepo, ["ls-tree", "-r", "--name-only", ref, "--", mirrorPath], {
+      encoding: "utf8",
+    });
     stdout
-      .split('\n')
-      .map(line => line.trim())
+      .split("\n")
+      .map((line) => line.trim())
       .filter(Boolean)
-      .forEach(file => files.add(file))
+      .forEach((file) => files.add(file));
   }
 
-  return [...files].sort()
+  return [...files].sort();
 }
 
 function readFileAtRef(sourceRepo, ref, relativePath) {
-  return runGit(sourceRepo, ['show', `${ref}:${relativePath}`], { encoding: 'buffer' })
+  return runGit(sourceRepo, ["show", `${ref}:${relativePath}`], { encoding: "buffer" });
 }
 
 function ensureParentDir(filePath) {
-  mkdirSync(path.dirname(filePath), { recursive: true })
+  mkdirSync(path.dirname(filePath), { recursive: true });
 }
 
 function walkFiles(rootDir) {
-  if (!statExists(rootDir))
-    return []
+  if (!statExists(rootDir)) return [];
 
-  const output = []
-  const stack = ['']
+  const output = [];
+  const stack = [""];
 
   while (stack.length > 0) {
-    const relativeDir = stack.pop()
-    const absoluteDir = path.join(rootDir, relativeDir)
+    const relativeDir = stack.pop();
+    const absoluteDir = path.join(rootDir, relativeDir);
 
     for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
-      const relativePath = path.posix.join(relativeDir.split(path.sep).join('/'), entry.name)
+      const relativePath = path.posix.join(relativeDir.split(path.sep).join("/"), entry.name);
       if (entry.isDirectory()) {
-        stack.push(relativePath)
-      }
-      else {
-        output.push(relativePath)
+        stack.push(relativePath);
+      } else {
+        output.push(relativePath);
       }
     }
   }
 
-  return output.sort()
+  return output.sort();
 }
 
 function statExists(filePath) {
   try {
-    statSync(filePath)
-    return true
-  }
-  catch {
-    return false
+    statSync(filePath);
+    return true;
+  } catch {
+    return false;
   }
 }
 
 function syncMirror({ sourceRepo, targetDir, ref, mirrorPaths, dryRun }) {
-  const commit = runGit(sourceRepo, ['rev-parse', `${ref}^{commit}`], { encoding: 'utf8' }).trim()
-  const files = listFilesAtRef(sourceRepo, ref, mirrorPaths)
+  const commit = runGit(sourceRepo, ["rev-parse", `${ref}^{commit}`], { encoding: "utf8" }).trim();
+  const files = listFilesAtRef(sourceRepo, ref, mirrorPaths);
 
-  if (files.length === 0)
-    fail(`no files found for ref ${ref}`)
+  if (files.length === 0) fail(`no files found for ref ${ref}`);
 
-  const existingFiles = walkFiles(targetDir).filter(file => !CONTROL_FILES.has(path.posix.basename(file)))
-  const nextFiles = new Set(files)
-  const removed = existingFiles.filter(file => !nextFiles.has(file))
+  const existingFiles = walkFiles(targetDir).filter(
+    (file) => !CONTROL_FILES.has(path.posix.basename(file)),
+  );
+  const nextFiles = new Set(files);
+  const removed = existingFiles.filter((file) => !nextFiles.has(file));
 
   if (dryRun) {
-    console.log(`[sync-shiki-compat] ref=${ref} commit=${commit}`)
-    console.log(`[sync-shiki-compat] target=${targetDir}`)
-    console.log(`[sync-shiki-compat] files=${files.length} removed=${removed.length}`)
-    return
+    console.log(`[sync-shiki-compat] ref=${ref} commit=${commit}`);
+    console.log(`[sync-shiki-compat] target=${targetDir}`);
+    console.log(`[sync-shiki-compat] files=${files.length} removed=${removed.length}`);
+    return;
   }
 
-  mkdirSync(targetDir, { recursive: true })
+  mkdirSync(targetDir, { recursive: true });
 
-  for (const relativePath of removed)
-    rmSync(path.join(targetDir, relativePath), { force: true })
+  for (const relativePath of removed) rmSync(path.join(targetDir, relativePath), { force: true });
 
   for (const relativePath of files) {
-    const destination = path.join(targetDir, relativePath)
-    ensureParentDir(destination)
-    writeFileSync(destination, readFileAtRef(sourceRepo, ref, relativePath))
+    const destination = path.join(targetDir, relativePath);
+    ensureParentDir(destination);
+    writeFileSync(destination, readFileAtRef(sourceRepo, ref, relativePath));
   }
 
   const metadata = {
-    source: 'shikijs/shiki',
+    source: "shikijs/shiki",
     ref,
     commit,
     importedAt: new Date().toISOString(),
     paths: mirrorPaths,
-  }
-  writeFileSync(path.join(targetDir, '.source.json'), `${JSON.stringify(metadata, null, 2)}\n`)
+  };
+  writeFileSync(path.join(targetDir, ".source.json"), `${JSON.stringify(metadata, null, 2)}\n`);
 
-  console.log(`[sync-shiki-compat] imported ${files.length} files from ${ref} (${commit})`)
+  console.log(`[sync-shiki-compat] imported ${files.length} files from ${ref} (${commit})`);
 }
 
 function checkMirror({ sourceRepo, targetDir, ref, mirrorPaths }) {
-  if (!statExists(targetDir))
-    fail(`mirror directory does not exist: ${targetDir}`)
+  if (!statExists(targetDir)) fail(`mirror directory does not exist: ${targetDir}`);
 
-  const files = listFilesAtRef(sourceRepo, ref, mirrorPaths)
-  const expected = new Set(files)
-  const existing = walkFiles(targetDir).filter(file => !CONTROL_FILES.has(path.posix.basename(file)))
-  const unexpected = existing.filter(file => !expected.has(file))
-  const missing = files.filter(file => !existing.includes(file))
+  const files = listFilesAtRef(sourceRepo, ref, mirrorPaths);
+  const expected = new Set(files);
+  const existing = walkFiles(targetDir).filter(
+    (file) => !CONTROL_FILES.has(path.posix.basename(file)),
+  );
+  const unexpected = existing.filter((file) => !expected.has(file));
+  const missing = files.filter((file) => !existing.includes(file));
 
-  if (unexpected.length > 0)
-    fail(`mirror has unexpected files, first example: ${unexpected[0]}`)
-  if (missing.length > 0)
-    fail(`mirror is missing files, first example: ${missing[0]}`)
+  if (unexpected.length > 0) fail(`mirror has unexpected files, first example: ${unexpected[0]}`);
+  if (missing.length > 0) fail(`mirror is missing files, first example: ${missing[0]}`);
 
   for (const relativePath of files) {
-    const actual = readFileSync(path.join(targetDir, relativePath))
-    const expectedContent = readFileAtRef(sourceRepo, ref, relativePath)
-    if (!actual.equals(expectedContent))
-      fail(`mirror drift detected in ${relativePath}`)
+    const actual = readFileSync(path.join(targetDir, relativePath));
+    const expectedContent = readFileAtRef(sourceRepo, ref, relativePath);
+    if (!actual.equals(expectedContent)) fail(`mirror drift detected in ${relativePath}`);
   }
 
-  console.log(`[sync-shiki-compat] mirror matches ${ref}`)
+  console.log(`[sync-shiki-compat] mirror matches ${ref}`);
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(process.argv.slice(2));
 if (args.help) {
-  printHelp()
-  process.exit(0)
+  printHelp();
+  process.exit(0);
 }
 
-const mirrorPaths = loadMirrorPaths(args.pathsFile)
-const metadataPath = path.join(args.targetDir, '.source.json')
-const ref = resolveRef(args.sourceRepo, args.ref, metadataPath, args.check)
+const mirrorPaths = loadMirrorPaths(args.pathsFile);
+const metadataPath = path.join(args.targetDir, ".source.json");
+const ref = resolveRef(args.sourceRepo, args.ref, metadataPath, args.check);
 
 if (args.check)
-  checkMirror({ sourceRepo: args.sourceRepo, targetDir: args.targetDir, ref, mirrorPaths })
+  checkMirror({ sourceRepo: args.sourceRepo, targetDir: args.targetDir, ref, mirrorPaths });
 else
-  syncMirror({ sourceRepo: args.sourceRepo, targetDir: args.targetDir, ref, mirrorPaths, dryRun: args.dryRun })
+  syncMirror({
+    sourceRepo: args.sourceRepo,
+    targetDir: args.targetDir,
+    ref,
+    mirrorPaths,
+    dryRun: args.dryRun,
+  });

--- a/node/scripts/sync-vscode-textmate-oracle.mjs
+++ b/node/scripts/sync-vscode-textmate-oracle.mjs
@@ -1,68 +1,61 @@
-import { Buffer } from 'node:buffer'
-import { spawnSync } from 'node:child_process'
-import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
-import path from 'node:path'
-import process from 'node:process'
+import { Buffer } from "node:buffer";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
 
-const CONTROL_FILES = new Set(['.source.json'])
+const CONTROL_FILES = new Set([".source.json"]);
 
 function fail(message) {
-  console.error(`[sync-vscode-textmate-oracle] ${message}`)
-  process.exit(1)
+  console.error(`[sync-vscode-textmate-oracle] ${message}`);
+  process.exit(1);
 }
 
 function runGit(cwd, args, options = {}) {
-  const result = spawnSync('git', args, {
+  const result = spawnSync("git", args, {
     cwd,
-    encoding: options.encoding === 'buffer' || options.encoding === undefined
-      ? undefined
-      : options.encoding,
+    encoding:
+      options.encoding === "buffer" || options.encoding === undefined
+        ? undefined
+        : options.encoding,
     input: options.input,
     maxBuffer: 64 * 1024 * 1024,
-    stdio: [options.input === undefined ? 'ignore' : 'pipe', 'pipe', 'pipe'],
-  })
+    stdio: [options.input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+  });
 
   if (result.status !== 0) {
     const stderr = Buffer.isBuffer(result.stderr)
-      ? result.stderr.toString('utf8').trim()
-      : String(result.stderr || '').trim()
-    fail(`git ${args.join(' ')} failed${stderr ? `: ${stderr}` : ''}`)
+      ? result.stderr.toString("utf8").trim()
+      : String(result.stderr || "").trim();
+    fail(`git ${args.join(" ")} failed${stderr ? `: ${stderr}` : ""}`);
   }
 
-  return result.stdout
+  return result.stdout;
 }
 
 function parseArgs(argv) {
   const args = {
     sourceRepo: process.cwd(),
-    targetDir: path.join(process.cwd(), 'compat/upstream/vscode-textmate'),
-    pathsFile: path.join(process.cwd(), 'compat/vscode-textmate-paths.json'),
+    targetDir: path.join(process.cwd(), "compat/upstream/vscode-textmate"),
+    pathsFile: path.join(process.cwd(), "compat/vscode-textmate-paths.json"),
     check: false,
     dryRun: false,
-    ref: '',
-  }
+    ref: "",
+  };
 
   for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index]
-    if (arg === '--source-repo')
-      args.sourceRepo = path.resolve(argv[++index] || '')
-    else if (arg === '--target-dir')
-      args.targetDir = path.resolve(argv[++index] || '')
-    else if (arg === '--paths-file')
-      args.pathsFile = path.resolve(argv[++index] || '')
-    else if (arg === '--ref')
-      args.ref = argv[++index] || ''
-    else if (arg === '--check')
-      args.check = true
-    else if (arg === '--dry-run')
-      args.dryRun = true
-    else if (arg === '--help')
-      args.help = true
-    else
-      fail(`unknown argument: ${arg}`)
+    const arg = argv[index];
+    if (arg === "--source-repo") args.sourceRepo = path.resolve(argv[++index] || "");
+    else if (arg === "--target-dir") args.targetDir = path.resolve(argv[++index] || "");
+    else if (arg === "--paths-file") args.pathsFile = path.resolve(argv[++index] || "");
+    else if (arg === "--ref") args.ref = argv[++index] || "";
+    else if (arg === "--check") args.check = true;
+    else if (arg === "--dry-run") args.dryRun = true;
+    else if (arg === "--help") args.help = true;
+    else fail(`unknown argument: ${arg}`);
   }
 
-  return args
+  return args;
 }
 
 function printHelp() {
@@ -75,213 +68,188 @@ Options:
   --check               Verify the existing mirror matches the source ref
   --dry-run             Print the import plan without writing files
   --help                Show this help
-`)
+`);
 }
 
 function loadMirrorPaths(pathsFile) {
-  const raw = JSON.parse(readFileSync(pathsFile, 'utf8'))
+  const raw = JSON.parse(readFileSync(pathsFile, "utf8"));
   if (!Array.isArray(raw) || raw.length === 0)
-    fail(`paths file must be a non-empty JSON array: ${pathsFile}`)
+    fail(`paths file must be a non-empty JSON array: ${pathsFile}`);
 
   return raw.map((entry) => {
-    if (typeof entry !== 'string' || !entry.trim())
-      fail(`invalid path entry in ${pathsFile}`)
-    return entry.replace(/\\/g, '/').replace(/\/+$/, '')
-  })
+    if (typeof entry !== "string" || !entry.trim()) fail(`invalid path entry in ${pathsFile}`);
+    return entry.replace(/\\/g, "/").replace(/\/+$/, "");
+  });
 }
 
 function resolveRef(ref, metadataPath, checkMode) {
-  if (ref)
-    return ref
+  if (ref) return ref;
 
-  if (!checkMode)
-    fail('missing required --ref')
+  if (!checkMode) fail("missing required --ref");
 
-  const metadata = JSON.parse(readFileSync(metadataPath, 'utf8'))
-  if (typeof metadata.ref !== 'string' || !metadata.ref)
-    fail(`mirror metadata does not contain a ref: ${metadataPath}`)
-  return metadata.ref
+  const metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
+  if (typeof metadata.ref !== "string" || !metadata.ref)
+    fail(`mirror metadata does not contain a ref: ${metadataPath}`);
+  return metadata.ref;
 }
 
 function listFilesAtRef(sourceRepo, ref, mirrorPaths) {
-  const files = new Set()
+  const files = new Set();
 
   for (const mirrorPath of mirrorPaths) {
-    const stdout = runGit(
-      sourceRepo,
-      ['ls-tree', '-r', '--name-only', ref, '--', mirrorPath],
-      { encoding: 'utf8' },
-    )
+    const stdout = runGit(sourceRepo, ["ls-tree", "-r", "--name-only", ref, "--", mirrorPath], {
+      encoding: "utf8",
+    });
     stdout
-      .split('\n')
-      .map(line => line.trim())
+      .split("\n")
+      .map((line) => line.trim())
       .filter(Boolean)
-      .forEach(file => files.add(file))
+      .forEach((file) => files.add(file));
   }
 
-  return [...files].sort()
+  return [...files].sort();
 }
 
 function readFilesAtRef(sourceRepo, ref, relativePaths) {
-  const input = `${relativePaths.map(file => `${ref}:${file}`).join('\n')}\n`
-  const output = runGit(sourceRepo, ['cat-file', '--batch'], {
-    encoding: 'buffer',
+  const input = `${relativePaths.map((file) => `${ref}:${file}`).join("\n")}\n`;
+  const output = runGit(sourceRepo, ["cat-file", "--batch"], {
+    encoding: "buffer",
     input,
-  })
-  const files = new Map()
-  let offset = 0
+  });
+  const files = new Map();
+  let offset = 0;
 
   for (const relativePath of relativePaths) {
-    const headerEnd = output.indexOf(0x0A, offset)
-    if (headerEnd === -1)
-      fail(`invalid git cat-file response for ${relativePath}`)
+    const headerEnd = output.indexOf(0x0a, offset);
+    if (headerEnd === -1) fail(`invalid git cat-file response for ${relativePath}`);
 
-    const header = output.subarray(offset, headerEnd).toString('utf8')
-    if (header.endsWith(' missing'))
-      fail(`missing ${relativePath} at ${ref}`)
+    const header = output.subarray(offset, headerEnd).toString("utf8");
+    if (header.endsWith(" missing")) fail(`missing ${relativePath} at ${ref}`);
 
-    const size = Number(header.split(' ').at(-1))
+    const size = Number(header.split(" ").at(-1));
     if (!Number.isSafeInteger(size) || size < 0)
-      fail(`invalid git cat-file size for ${relativePath}: ${header}`)
+      fail(`invalid git cat-file size for ${relativePath}: ${header}`);
 
-    const contentStart = headerEnd + 1
-    const contentEnd = contentStart + size
-    if (contentEnd >= output.length || output[contentEnd] !== 0x0A)
-      fail(`truncated git cat-file response for ${relativePath}`)
+    const contentStart = headerEnd + 1;
+    const contentEnd = contentStart + size;
+    if (contentEnd >= output.length || output[contentEnd] !== 0x0a)
+      fail(`truncated git cat-file response for ${relativePath}`);
 
-    files.set(relativePath, output.subarray(contentStart, contentEnd))
-    offset = contentEnd + 1
+    files.set(relativePath, output.subarray(contentStart, contentEnd));
+    offset = contentEnd + 1;
   }
 
-  return files
+  return files;
 }
 
 function ensureParentDir(filePath) {
-  mkdirSync(path.dirname(filePath), { recursive: true })
+  mkdirSync(path.dirname(filePath), { recursive: true });
 }
 
 function walkFiles(rootDir) {
-  if (!statExists(rootDir))
-    return []
+  if (!statExists(rootDir)) return [];
 
-  const output = []
-  const stack = ['']
+  const output = [];
+  const stack = [""];
   while (stack.length > 0) {
-    const relativeDir = stack.pop()
-    const absoluteDir = path.join(rootDir, relativeDir)
+    const relativeDir = stack.pop();
+    const absoluteDir = path.join(rootDir, relativeDir);
 
     for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
-      const relativePath = path.posix.join(
-        relativeDir.split(path.sep).join('/'),
-        entry.name,
-      )
-      if (entry.isDirectory())
-        stack.push(relativePath)
-      else
-        output.push(relativePath)
+      const relativePath = path.posix.join(relativeDir.split(path.sep).join("/"), entry.name);
+      if (entry.isDirectory()) stack.push(relativePath);
+      else output.push(relativePath);
     }
   }
 
-  return output.sort()
+  return output.sort();
 }
 
 function statExists(filePath) {
   try {
-    statSync(filePath)
-    return true
-  }
-  catch {
-    return false
+    statSync(filePath);
+    return true;
+  } catch {
+    return false;
   }
 }
 
 function syncMirror({ sourceRepo, targetDir, ref, mirrorPaths, dryRun }) {
-  const commit = runGit(
-    sourceRepo,
-    ['rev-parse', `${ref}^{commit}`],
-    { encoding: 'utf8' },
-  ).trim()
-  const files = listFilesAtRef(sourceRepo, ref, mirrorPaths)
+  const commit = runGit(sourceRepo, ["rev-parse", `${ref}^{commit}`], { encoding: "utf8" }).trim();
+  const files = listFilesAtRef(sourceRepo, ref, mirrorPaths);
 
-  if (files.length === 0)
-    fail(`no files found for ref ${ref}`)
+  if (files.length === 0) fail(`no files found for ref ${ref}`);
 
-  const contents = readFilesAtRef(sourceRepo, ref, files)
-  const existingFiles = walkFiles(targetDir)
-    .filter(file => !CONTROL_FILES.has(path.posix.basename(file)))
-  const nextFiles = new Set(files)
-  const removed = existingFiles.filter(file => !nextFiles.has(file))
+  const contents = readFilesAtRef(sourceRepo, ref, files);
+  const existingFiles = walkFiles(targetDir).filter(
+    (file) => !CONTROL_FILES.has(path.posix.basename(file)),
+  );
+  const nextFiles = new Set(files);
+  const removed = existingFiles.filter((file) => !nextFiles.has(file));
 
   if (dryRun) {
-    console.log(`[sync-vscode-textmate-oracle] ref=${ref} commit=${commit}`)
-    console.log(`[sync-vscode-textmate-oracle] target=${targetDir}`)
-    console.log(`[sync-vscode-textmate-oracle] files=${files.length} removed=${removed.length}`)
-    return
+    console.log(`[sync-vscode-textmate-oracle] ref=${ref} commit=${commit}`);
+    console.log(`[sync-vscode-textmate-oracle] target=${targetDir}`);
+    console.log(`[sync-vscode-textmate-oracle] files=${files.length} removed=${removed.length}`);
+    return;
   }
 
-  mkdirSync(targetDir, { recursive: true })
-  for (const relativePath of removed)
-    rmSync(path.join(targetDir, relativePath), { force: true })
+  mkdirSync(targetDir, { recursive: true });
+  for (const relativePath of removed) rmSync(path.join(targetDir, relativePath), { force: true });
 
   for (const relativePath of files) {
-    const destination = path.join(targetDir, relativePath)
-    ensureParentDir(destination)
-    writeFileSync(destination, contents.get(relativePath))
+    const destination = path.join(targetDir, relativePath);
+    ensureParentDir(destination);
+    writeFileSync(destination, contents.get(relativePath));
   }
 
   const metadata = {
-    source: 'microsoft/vscode-textmate',
+    source: "microsoft/vscode-textmate",
     ref,
     commit,
     importedAt: new Date().toISOString(),
     paths: mirrorPaths,
-  }
-  writeFileSync(
-    path.join(targetDir, '.source.json'),
-    `${JSON.stringify(metadata, null, 2)}\n`,
-  )
+  };
+  writeFileSync(path.join(targetDir, ".source.json"), `${JSON.stringify(metadata, null, 2)}\n`);
 
-  console.log(`[sync-vscode-textmate-oracle] imported ${files.length} files from ${ref} (${commit})`)
+  console.log(
+    `[sync-vscode-textmate-oracle] imported ${files.length} files from ${ref} (${commit})`,
+  );
 }
 
 function checkMirror({ sourceRepo, targetDir, ref, mirrorPaths }) {
-  if (!statExists(targetDir))
-    fail(`mirror directory does not exist: ${targetDir}`)
+  if (!statExists(targetDir)) fail(`mirror directory does not exist: ${targetDir}`);
 
-  const files = listFilesAtRef(sourceRepo, ref, mirrorPaths)
-  const contents = readFilesAtRef(sourceRepo, ref, files)
-  const expected = new Set(files)
-  const existing = walkFiles(targetDir)
-    .filter(file => !CONTROL_FILES.has(path.posix.basename(file)))
-  const unexpected = existing.filter(file => !expected.has(file))
-  const missing = files.filter(file => !existing.includes(file))
+  const files = listFilesAtRef(sourceRepo, ref, mirrorPaths);
+  const contents = readFilesAtRef(sourceRepo, ref, files);
+  const expected = new Set(files);
+  const existing = walkFiles(targetDir).filter(
+    (file) => !CONTROL_FILES.has(path.posix.basename(file)),
+  );
+  const unexpected = existing.filter((file) => !expected.has(file));
+  const missing = files.filter((file) => !existing.includes(file));
 
-  if (unexpected.length > 0)
-    fail(`mirror has unexpected files, first example: ${unexpected[0]}`)
-  if (missing.length > 0)
-    fail(`mirror is missing files, first example: ${missing[0]}`)
+  if (unexpected.length > 0) fail(`mirror has unexpected files, first example: ${unexpected[0]}`);
+  if (missing.length > 0) fail(`mirror is missing files, first example: ${missing[0]}`);
 
   for (const relativePath of files) {
-    const actual = readFileSync(path.join(targetDir, relativePath))
-    const expectedContent = contents.get(relativePath)
-    if (!actual.equals(expectedContent))
-      fail(`mirror drift detected in ${relativePath}`)
+    const actual = readFileSync(path.join(targetDir, relativePath));
+    const expectedContent = contents.get(relativePath);
+    if (!actual.equals(expectedContent)) fail(`mirror drift detected in ${relativePath}`);
   }
 
-  console.log(`[sync-vscode-textmate-oracle] mirror matches ${ref}`)
+  console.log(`[sync-vscode-textmate-oracle] mirror matches ${ref}`);
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(process.argv.slice(2));
 if (args.help) {
-  printHelp()
-  process.exit(0)
+  printHelp();
+  process.exit(0);
 }
 
-const mirrorPaths = loadMirrorPaths(args.pathsFile)
-const metadataPath = path.join(args.targetDir, '.source.json')
-const ref = resolveRef(args.ref, metadataPath, args.check)
+const mirrorPaths = loadMirrorPaths(args.pathsFile);
+const metadataPath = path.join(args.targetDir, ".source.json");
+const ref = resolveRef(args.ref, metadataPath, args.check);
 
-if (args.check)
-  checkMirror({ ...args, ref, mirrorPaths })
-else
-  syncMirror({ ...args, ref, mirrorPaths })
+if (args.check) checkMirror({ ...args, ref, mirrorPaths });
+else syncMirror({ ...args, ref, mirrorPaths });

--- a/node/scripts/test-docs-drift.mjs
+++ b/node/scripts/test-docs-drift.mjs
@@ -1,9 +1,9 @@
-import assert from 'node:assert/strict'
-import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
-import { test } from 'node:test'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   checkDocsDrift,
@@ -12,161 +12,195 @@ import {
   SHIKI_BASELINE_DOCS,
   SHIKI_SOURCE,
   STALE_GUIDANCE,
-} from './check-docs-drift.mjs'
+} from "./check-docs-drift.mjs";
 
 // The fixture is a copy of the real documents, so every case below starts
 // from a tree the checker accepts and injects exactly one kind of drift.
-const repoRoot = join(fileURLToPath(new URL('.', import.meta.url)), '../..')
-const fixtureFiles = [...new Set([
-  'CLAUDE.md',
-  SHIKI_SOURCE,
-  FERRIKI_PACKAGE,
-  ...STALE_GUIDANCE.map(([relative]) => relative),
-  ...SHIKI_BASELINE_DOCS,
-  ...NODE_FLOOR_DOCS,
-])]
+const repoRoot = join(fileURLToPath(new URL(".", import.meta.url)), "../..");
+const fixtureFiles = [
+  ...new Set([
+    "CLAUDE.md",
+    SHIKI_SOURCE,
+    FERRIKI_PACKAGE,
+    ...STALE_GUIDANCE.map(([relative]) => relative),
+    ...SHIKI_BASELINE_DOCS,
+    ...NODE_FLOOR_DOCS,
+  ]),
+];
 
 async function withFixture(run) {
-  const root = await mkdtemp(join(tmpdir(), 'ferriki-docs-drift-'))
+  const root = await mkdtemp(join(tmpdir(), "ferriki-docs-drift-"));
   try {
     for (const relative of fixtureFiles) {
-      const target = join(root, relative)
-      await mkdir(dirname(target), { recursive: true })
-      await copyFile(join(repoRoot, relative), target)
+      const target = join(root, relative);
+      await mkdir(dirname(target), { recursive: true });
+      await copyFile(join(repoRoot, relative), target);
     }
-    await run(root)
-  }
-  finally {
-    await rm(root, { recursive: true, force: true })
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
   }
 }
 
 async function edit(root, relative, transform) {
-  const path = join(root, relative)
-  const source = await readFile(path, 'utf8')
-  const next = transform(source)
-  assert.notEqual(next, source, `fixture edit of ${relative} must change the file`)
-  await writeFile(path, next)
+  const path = join(root, relative);
+  const source = await readFile(path, "utf8");
+  const next = transform(source);
+  assert.notEqual(next, source, `fixture edit of ${relative} must change the file`);
+  await writeFile(path, next);
 }
 
 async function editJson(root, relative, transform) {
-  await edit(root, relative, source => `${JSON.stringify(transform(JSON.parse(source)), null, 2)}\n`)
+  await edit(
+    root,
+    relative,
+    (source) => `${JSON.stringify(transform(JSON.parse(source)), null, 2)}\n`,
+  );
 }
 
-const shikiRef = JSON.parse(await readFile(join(repoRoot, SHIKI_SOURCE), 'utf8')).ref
-const nodeFloor = JSON.parse(await readFile(join(repoRoot, FERRIKI_PACKAGE), 'utf8')).engines.node.replace(/^\D*/, '')
-const staleShikiRef = 'v4.3.1'
-const staleNodeFloor = '20'
+const shikiRef = JSON.parse(await readFile(join(repoRoot, SHIKI_SOURCE), "utf8")).ref;
+const nodeFloor = JSON.parse(
+  await readFile(join(repoRoot, FERRIKI_PACKAGE), "utf8"),
+).engines.node.replace(/^\D*/, "");
+const staleShikiRef = "v4.3.1";
+const staleNodeFloor = "20";
 // Documents write the baseline as `Shiki v4.4.3` or `Shiki **v4.4.3**`.
-const pinnedShikiMention = new RegExp(`Shiki (\\*{0,2})${shikiRef.replaceAll('.', '\\.')}`)
-assert.notEqual(staleShikiRef, shikiRef, 'the injected Shiki version must differ from the pinned one')
-assert.notEqual(staleNodeFloor, nodeFloor, 'the injected Node version must differ from the declared floor')
+const pinnedShikiMention = new RegExp(`Shiki (\\*{0,2})${shikiRef.replaceAll(".", "\\.")}`);
+assert.notEqual(
+  staleShikiRef,
+  shikiRef,
+  "the injected Shiki version must differ from the pinned one",
+);
+assert.notEqual(
+  staleNodeFloor,
+  nodeFloor,
+  "the injected Node version must differ from the declared floor",
+);
 
 // The document lists are hard-coded in the checker; keep the entry points a
 // contributor reads first under the check even if the lists are trimmed.
-for (const relative of ['README.md', 'CONTRIBUTING.md', 'docs/compatibility.md', 'node/ferriki/README.md']) {
-  assert(SHIKI_BASELINE_DOCS.includes(relative), `${relative} must stay under the Shiki baseline check`)
-  assert(NODE_FLOOR_DOCS.includes(relative), `${relative} must stay under the Node floor check`)
+for (const relative of [
+  "README.md",
+  "CONTRIBUTING.md",
+  "docs/compatibility.md",
+  "node/ferriki/README.md",
+]) {
+  assert(
+    SHIKI_BASELINE_DOCS.includes(relative),
+    `${relative} must stay under the Shiki baseline check`,
+  );
+  assert(NODE_FLOOR_DOCS.includes(relative), `${relative} must stay under the Node floor check`);
 }
-assert(NODE_FLOOR_DOCS.includes('AGENTS.md'), 'AGENTS.md must stay under the Node floor check')
+assert(NODE_FLOOR_DOCS.includes("AGENTS.md"), "AGENTS.md must stay under the Node floor check");
 
-test('accepts the checked-in documents and reports both sources', async () => {
+test("accepts the checked-in documents and reports both sources", async () => {
   await withFixture(async (root) => {
-    assert.deepEqual(await checkDocsDrift(root), { shikiRef, nodeFloor })
-  })
-})
+    assert.deepEqual(await checkDocsDrift(root), { shikiRef, nodeFloor });
+  });
+});
 
 for (const relative of SHIKI_BASELINE_DOCS) {
   test(`rejects a stale Shiki baseline in ${relative}`, async () => {
     await withFixture(async (root) => {
-      await edit(root, relative, source => source.replace(pinnedShikiMention, `Shiki $1${staleShikiRef}`))
-      await assert.rejects(
-        checkDocsDrift(root),
-        { message: `${relative} names a stale Shiki baseline (${staleShikiRef}); the mirror pins ${shikiRef}` },
-      )
-    })
-  })
+      await edit(root, relative, (source) =>
+        source.replace(pinnedShikiMention, `Shiki $1${staleShikiRef}`),
+      );
+      await assert.rejects(checkDocsDrift(root), {
+        message: `${relative} names a stale Shiki baseline (${staleShikiRef}); the mirror pins ${shikiRef}`,
+      });
+    });
+  });
 }
 
-test('rejects a document that stops naming the Shiki baseline', async () => {
+test("rejects a document that stops naming the Shiki baseline", async () => {
   await withFixture(async (root) => {
-    await edit(root, 'docs/compatibility.md', source => source.replaceAll(new RegExp(pinnedShikiMention, 'g'), 'Shiki'))
-    await assert.rejects(
-      checkDocsDrift(root),
-      { message: `docs/compatibility.md must name the pinned Shiki baseline (${shikiRef})` },
-    )
-  })
-})
+    await edit(root, "docs/compatibility.md", (source) =>
+      source.replaceAll(new RegExp(pinnedShikiMention, "g"), "Shiki"),
+    );
+    await assert.rejects(checkDocsDrift(root), {
+      message: `docs/compatibility.md must name the pinned Shiki baseline (${shikiRef})`,
+    });
+  });
+});
 
 for (const relative of NODE_FLOOR_DOCS) {
   test(`rejects a stale Node floor in ${relative}`, async () => {
     await withFixture(async (root) => {
-      await edit(root, relative, source => `${source}\nRequires Node.js >= ${staleNodeFloor}.\n`)
-      await assert.rejects(
-        checkDocsDrift(root),
-        { message: `${relative} states a Node version other than the declared floor ${nodeFloor}: ${staleNodeFloor}` },
-      )
-    })
-  })
+      await edit(root, relative, (source) => `${source}\nRequires Node.js >= ${staleNodeFloor}.\n`);
+      await assert.rejects(checkDocsDrift(root), {
+        message: `${relative} states a Node version other than the declared floor ${nodeFloor}: ${staleNodeFloor}`,
+      });
+    });
+  });
 }
 
-test('rejects a document that stops stating the Node floor', async () => {
+test("rejects a document that stops stating the Node floor", async () => {
   await withFixture(async (root) => {
-    await edit(root, 'AGENTS.md', source => source.replaceAll(nodeFloor, 'a supported version'))
-    await assert.rejects(
-      checkDocsDrift(root),
-      { message: `AGENTS.md must state the Node floor ${nodeFloor} declared by ${FERRIKI_PACKAGE}` },
-    )
-  })
-})
+    await edit(root, "AGENTS.md", (source) => source.replaceAll(nodeFloor, "a supported version"));
+    await assert.rejects(checkDocsDrift(root), {
+      message: `AGENTS.md must state the Node floor ${nodeFloor} declared by ${FERRIKI_PACKAGE}`,
+    });
+  });
+});
 
-test('fails every baseline document when the Shiki source moves ahead of the prose', async () => {
+test("fails every baseline document when the Shiki source moves ahead of the prose", async () => {
   await withFixture(async (root) => {
-    await editJson(root, SHIKI_SOURCE, source => ({ ...source, ref: 'v9.9.9' }))
-    await assert.rejects(
-      checkDocsDrift(root),
-      { message: `${SHIKI_BASELINE_DOCS[0]} names a stale Shiki baseline (${shikiRef}); the mirror pins v9.9.9` },
-    )
-  })
-})
+    await editJson(root, SHIKI_SOURCE, (source) => ({ ...source, ref: "v9.9.9" }));
+    await assert.rejects(checkDocsDrift(root), {
+      message: `${SHIKI_BASELINE_DOCS[0]} names a stale Shiki baseline (${shikiRef}); the mirror pins v9.9.9`,
+    });
+  });
+});
 
-test('fails every floor document when engines.node moves ahead of the prose', async () => {
+test("fails every floor document when engines.node moves ahead of the prose", async () => {
   await withFixture(async (root) => {
-    await editJson(root, FERRIKI_PACKAGE, pkg => ({ ...pkg, engines: { ...pkg.engines, node: '>=99.0.0' } }))
-    await assert.rejects(
-      checkDocsDrift(root),
-      { message: `${NODE_FLOOR_DOCS[0]} must state the Node floor 99.0.0 declared by ${FERRIKI_PACKAGE}` },
-    )
-  })
-})
+    await editJson(root, FERRIKI_PACKAGE, (pkg) => ({
+      ...pkg,
+      engines: { ...pkg.engines, node: ">=99.0.0" },
+    }));
+    await assert.rejects(checkDocsDrift(root), {
+      message: `${NODE_FLOOR_DOCS[0]} must state the Node floor 99.0.0 declared by ${FERRIKI_PACKAGE}`,
+    });
+  });
+});
 
-test('rejects a Shiki source that is not an exact release tag', async () => {
+test("rejects a Shiki source that is not an exact release tag", async () => {
   await withFixture(async (root) => {
-    await editJson(root, SHIKI_SOURCE, source => ({ ...source, ref: 'main' }))
-    await assert.rejects(checkDocsDrift(root), { message: `${SHIKI_SOURCE} must pin an exact Shiki release tag` })
-  })
-})
+    await editJson(root, SHIKI_SOURCE, (source) => ({ ...source, ref: "main" }));
+    await assert.rejects(checkDocsDrift(root), {
+      message: `${SHIKI_SOURCE} must pin an exact Shiki release tag`,
+    });
+  });
+});
 
-test('rejects an engines.node range without an exact floor', async () => {
+test("rejects an engines.node range without an exact floor", async () => {
   await withFixture(async (root) => {
-    await editJson(root, FERRIKI_PACKAGE, pkg => ({ ...pkg, engines: { ...pkg.engines, node: '>=22' } }))
-    await assert.rejects(
-      checkDocsDrift(root),
-      { message: `${FERRIKI_PACKAGE} must declare an exact Node floor in \`engines.node\`` },
-    )
-  })
-})
+    await editJson(root, FERRIKI_PACKAGE, (pkg) => ({
+      ...pkg,
+      engines: { ...pkg.engines, node: ">=22" },
+    }));
+    await assert.rejects(checkDocsDrift(root), {
+      message: `${FERRIKI_PACKAGE} must declare an exact Node floor in \`engines.node\``,
+    });
+  });
+});
 
-test('still rejects stale guidance phrases', async () => {
+test("still rejects stale guidance phrases", async () => {
   await withFixture(async (root) => {
-    await edit(root, 'AGENTS.md', source => `${source}\nSet FERRIKI_BACKEND=js to use the JS engine.\n`)
-    await assert.rejects(checkDocsDrift(root), { message: 'AGENTS.md contains stale guidance: FERRIKI_BACKEND' })
-  })
-})
+    await edit(
+      root,
+      "AGENTS.md",
+      (source) => `${source}\nSet FERRIKI_BACKEND=js to use the JS engine.\n`,
+    );
+    await assert.rejects(checkDocsDrift(root), {
+      message: "AGENTS.md contains stale guidance: FERRIKI_BACKEND",
+    });
+  });
+});
 
-test('still requires CLAUDE.md to be the pointer line', async () => {
+test("still requires CLAUDE.md to be the pointer line", async () => {
   await withFixture(async (root) => {
-    await edit(root, 'CLAUDE.md', () => '# Claude guidance\n')
-    await assert.rejects(checkDocsDrift(root), /CLAUDE\.md must be exactly the pointer line/)
-  })
-})
+    await edit(root, "CLAUDE.md", () => "# Claude guidance\n");
+    await assert.rejects(checkDocsDrift(root), /CLAUDE\.md must be exactly the pointer line/);
+  });
+});

--- a/node/scripts/test-npm-publish-verification.mjs
+++ b/node/scripts/test-npm-publish-verification.mjs
@@ -1,81 +1,77 @@
-import assert from 'node:assert/strict'
+import assert from "node:assert/strict";
 
-import {
-  MAX_ATTEMPTS,
-  registryVersionUrl,
-  verifyNpmPublication,
-} from './verify-npm-publish.mjs'
+import { MAX_ATTEMPTS, registryVersionUrl, verifyNpmPublication } from "./verify-npm-publish.mjs";
 
 assert.equal(
-  registryVersionUrl('ferriki-linux-x64-gnu', '0.2.0'),
-  'https://registry.npmjs.org/ferriki-linux-x64-gnu/0.2.0',
-)
+  registryVersionUrl("ferriki-linux-x64-gnu", "0.2.0"),
+  "https://registry.npmjs.org/ferriki-linux-x64-gnu/0.2.0",
+);
 
 // The sidecars are unscoped, but the helper still has to encode a scope for any
 // other package name it is handed.
 assert.equal(
-  registryVersionUrl('@sebastian-software/ferriki', '0.2.0'),
-  'https://registry.npmjs.org/%40sebastian-software%2Fferriki/0.2.0',
-)
+  registryVersionUrl("@sebastian-software/ferriki", "0.2.0"),
+  "https://registry.npmjs.org/%40sebastian-software%2Fferriki/0.2.0",
+);
 
-let attempts = 0
+let attempts = 0;
 await verifyNpmPublication({
-  packageName: 'ferriki',
-  version: '0.2.0',
-  publishResult: 'success',
+  packageName: "ferriki",
+  version: "0.2.0",
+  publishResult: "success",
   fetchImpl: async () => {
-    attempts += 1
+    attempts += 1;
     return {
       ok: attempts === 2,
       status: attempts === 2 ? 200 : 404,
       json: async () => ({
-        name: 'ferriki',
-        version: '0.2.0',
+        name: "ferriki",
+        version: "0.2.0",
         dist: { attestations: { provenance: {} } },
       }),
-    }
+    };
   },
   sleepImpl: async () => {},
-})
-assert.equal(attempts, 2)
+});
+assert.equal(attempts, 2);
 
-let wrongVersionAttempts = 0
+let wrongVersionAttempts = 0;
 await assert.rejects(
   verifyNpmPublication({
-    packageName: 'ferriki',
-    version: '0.2.0',
-    publishResult: 'success',
+    packageName: "ferriki",
+    version: "0.2.0",
+    publishResult: "success",
     fetchImpl: async () => {
-      wrongVersionAttempts += 1
+      wrongVersionAttempts += 1;
       return {
         ok: true,
         status: 200,
         json: async () => ({
-          name: 'ferriki',
-          version: '0.1.0',
+          name: "ferriki",
+          version: "0.1.0",
           dist: { attestations: { provenance: {} } },
         }),
-      }
+      };
     },
     sleepImpl: async () => {},
   }),
   /expected ferriki@0\.2\.0/,
-)
-assert.equal(wrongVersionAttempts, MAX_ATTEMPTS)
+);
+assert.equal(wrongVersionAttempts, MAX_ATTEMPTS);
 
 await assert.rejects(
   verifyNpmPublication({
-    packageName: 'ferriki',
-    version: '0.2.0',
-    publishResult: 'failure',
+    packageName: "ferriki",
+    version: "0.2.0",
+    publishResult: "failure",
     fetchImpl: async () => ({
       ok: true,
       status: 200,
-      json: async () => ({ name: 'ferriki', version: '0.2.0' }),
+      json: async () => ({ name: "ferriki", version: "0.2.0" }),
     }),
     sleepImpl: async () => {},
   }),
   /publish-npm concluded failure/,
-)
+);
 
-console.log('Ferriki npm publication verification contract passed')
+console.log("Ferriki npm publication verification contract passed");

--- a/node/scripts/verify-npm-publish.mjs
+++ b/node/scripts/verify-npm-publish.mjs
@@ -1,22 +1,22 @@
-import assert from 'node:assert/strict'
-import { spawnSync } from 'node:child_process'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-import { FERRIKI_PLATFORM_TARGETS } from '../ferriki/platforms.mjs'
+import { FERRIKI_PLATFORM_TARGETS } from "../ferriki/platforms.mjs";
 
-export const MAX_ATTEMPTS = 8
-export const RETRY_DELAY_MS = 15_000
-export const REQUEST_TIMEOUT_MS = 10_000
+export const MAX_ATTEMPTS = 8;
+export const RETRY_DELAY_MS = 15_000;
+export const REQUEST_TIMEOUT_MS = 10_000;
 
 export function registryVersionUrl(packageName, version) {
-  return `https://registry.npmjs.org/${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`
+  return `https://registry.npmjs.org/${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`;
 }
 
-const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds))
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
 export async function verifyNpmPublication({
   packageName,
@@ -25,117 +25,135 @@ export async function verifyNpmPublication({
   fetchImpl = fetch,
   sleepImpl = sleep,
 }) {
-  const registryUrl = registryVersionUrl(packageName, version)
-  let published = false
-  let provenance = false
-  let lastObservation = 'the registry did not return the expected package metadata'
+  const registryUrl = registryVersionUrl(packageName, version);
+  let published = false;
+  let provenance = false;
+  let lastObservation = "the registry did not return the expected package metadata";
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
     try {
       const response = await fetchImpl(registryUrl, {
-        cache: 'no-store',
+        cache: "no-store",
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-      })
+      });
       if (response.ok) {
-        const metadata = await response.json()
-        published = metadata.name === packageName && metadata.version === version
-        provenance = Boolean(metadata.dist?.attestations?.provenance)
+        const metadata = await response.json();
+        published = metadata.name === packageName && metadata.version === version;
+        provenance = Boolean(metadata.dist?.attestations?.provenance);
         if (published && provenance) {
-          console.log(`npm registry confirmed ${packageName}@${version} with provenance on attempt ${attempt}`)
-          break
+          console.log(
+            `npm registry confirmed ${packageName}@${version} with provenance on attempt ${attempt}`,
+          );
+          break;
         }
         lastObservation = published
-          ? 'registry metadata is public but has no provenance attestation'
-          : `registry returned ${metadata.name ?? 'unknown'}@${metadata.version ?? 'unknown'}`
+          ? "registry metadata is public but has no provenance attestation"
+          : `registry returned ${metadata.name ?? "unknown"}@${metadata.version ?? "unknown"}`;
+      } else {
+        lastObservation = `registry returned HTTP ${response.status}`;
       }
-      else {
-        lastObservation = `registry returned HTTP ${response.status}`
-      }
-    }
-    catch (error) {
-      lastObservation = `registry request failed: ${error.message}`
+    } catch (error) {
+      lastObservation = `registry request failed: ${error.message}`;
     }
 
-    console.log(`npm release verification attempt ${attempt}/${MAX_ATTEMPTS} for ${packageName}: ${lastObservation}`)
-    if (attempt < MAX_ATTEMPTS)
-      await sleepImpl(RETRY_DELAY_MS)
+    console.log(
+      `npm release verification attempt ${attempt}/${MAX_ATTEMPTS} for ${packageName}: ${lastObservation}`,
+    );
+    if (attempt < MAX_ATTEMPTS) await sleepImpl(RETRY_DELAY_MS);
   }
 
-  const failures = []
-  if (publishResult !== 'success')
-    failures.push(`publish-npm concluded ${publishResult}`)
+  const failures = [];
+  if (publishResult !== "success") failures.push(`publish-npm concluded ${publishResult}`);
   if (!published)
-    failures.push(`expected ${packageName}@${version} at ${registryUrl}; ${lastObservation}`)
-  if (!provenance)
-    failures.push(`expected npm provenance for ${packageName}@${version}`)
+    failures.push(`expected ${packageName}@${version} at ${registryUrl}; ${lastObservation}`);
+  if (!provenance) failures.push(`expected npm provenance for ${packageName}@${version}`);
   if (failures.length > 0)
-    throw new Error(`npm release verification failed: ${failures.join('; ')}`)
+    throw new Error(`npm release verification failed: ${failures.join("; ")}`);
 }
 
 async function verifyPublicInstall(packageName, version) {
-  const tempRoot = await mkdtemp(join(tmpdir(), 'ferriki-public-install-'))
-  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+  const tempRoot = await mkdtemp(join(tmpdir(), "ferriki-public-install-"));
+  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
   const run = (args, options = {}) => {
     const result = spawnSync(npm, args, {
       cwd: tempRoot,
-      encoding: 'utf8',
-      stdio: options.stdio ?? 'pipe',
-      shell: process.platform === 'win32',
+      encoding: "utf8",
+      stdio: options.stdio ?? "pipe",
+      shell: process.platform === "win32",
       ...options,
-    })
+    });
     if (result.status !== 0)
-      throw new Error(`npm ${args.join(' ')} failed:\n${result.stdout ?? ''}\n${result.stderr ?? ''}`)
-  }
+      throw new Error(
+        `npm ${args.join(" ")} failed:\n${result.stdout ?? ""}\n${result.stderr ?? ""}`,
+      );
+  };
 
   try {
-    run(['init', '--yes'], { stdio: 'ignore' })
-    run(['install', '--ignore-scripts', '--no-audit', '--no-fund', `${packageName}@${version}`], { stdio: 'ignore' })
-    const probe = join(tempRoot, 'probe.mjs')
-    await writeFile(probe, `
+    run(["init", "--yes"], { stdio: "ignore" });
+    run(["install", "--ignore-scripts", "--no-audit", "--no-fund", `${packageName}@${version}`], {
+      stdio: "ignore",
+    });
+    const probe = join(tempRoot, "probe.mjs");
+    await writeFile(
+      probe,
+      `
       const ferriki = await import(${JSON.stringify(packageName)})
       if (typeof ferriki.ferrikiVersion !== 'function' || !ferriki.ferrikiVersion())
         throw new Error('public Ferriki install did not load its native binding')
-    `)
-    const nodeResult = spawnSync(process.execPath, [probe], { cwd: tempRoot, encoding: 'utf8', stdio: 'pipe' })
+    `,
+    );
+    const nodeResult = spawnSync(process.execPath, [probe], {
+      cwd: tempRoot,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
     if (nodeResult.status !== 0)
-      throw new Error(`public Ferriki install probe failed:\n${nodeResult.stdout}\n${nodeResult.stderr}`)
-    console.log(`public npm install verified for ${packageName}@${version}`)
-  }
-  finally {
-    await rm(tempRoot, { recursive: true, force: true })
+      throw new Error(
+        `public Ferriki install probe failed:\n${nodeResult.stdout}\n${nodeResult.stderr}`,
+      );
+    console.log(`public npm install verified for ${packageName}@${version}`);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
   }
 }
 
 async function main() {
-  const scriptsDirectory = fileURLToPath(new URL('.', import.meta.url))
-  const packagePath = join(scriptsDirectory, '..', 'ferriki', 'package.json')
-  const packageJson = JSON.parse(await readFile(packagePath, 'utf8'))
-  assert(typeof packageJson.name === 'string' && typeof packageJson.version === 'string', 'invalid Ferriki package manifest')
+  const scriptsDirectory = fileURLToPath(new URL(".", import.meta.url));
+  const packagePath = join(scriptsDirectory, "..", "ferriki", "package.json");
+  const packageJson = JSON.parse(await readFile(packagePath, "utf8"));
+  assert(
+    typeof packageJson.name === "string" && typeof packageJson.version === "string",
+    "invalid Ferriki package manifest",
+  );
 
   const packages = [
     { name: packageJson.name, version: packageJson.version },
-    ...FERRIKI_PLATFORM_TARGETS.map(target => ({
+    ...FERRIKI_PLATFORM_TARGETS.map((target) => ({
       name: target.packageName,
       version: packageJson.optionalDependencies?.[target.packageName],
     })),
-  ]
+  ];
   for (const pkg of packages)
-    assert.equal(pkg.version, packageJson.version, `${pkg.name} must use the Ferriki release version`)
+    assert.equal(
+      pkg.version,
+      packageJson.version,
+      `${pkg.name} must use the Ferriki release version`,
+    );
 
-  const publishResult = process.env.NPM_PUBLISH_RESULT ?? 'unknown'
+  const publishResult = process.env.NPM_PUBLISH_RESULT ?? "unknown";
   for (const pkg of packages) {
     await verifyNpmPublication({
       packageName: pkg.name,
       version: pkg.version,
       publishResult,
-    })
+    });
   }
-  await verifyPublicInstall(packageJson.name, packageJson.version)
+  await verifyPublicInstall(packageJson.name, packageJson.version);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch((error) => {
-    console.error(error.message)
-    process.exitCode = 1
-  })
+    console.error(error.message);
+    process.exitCode = 1;
+  });
 }

--- a/node/scripts/write-release-summary.mjs
+++ b/node/scripts/write-release-summary.mjs
@@ -1,33 +1,35 @@
-import { appendFile } from 'node:fs/promises'
-import process from 'node:process'
+import { appendFile } from "node:fs/promises";
+import process from "node:process";
 
-const releasesCreated = process.env.RELEASES_CREATED === 'true'
-const forcePublish = process.env.FORCE_PUBLISH === 'true'
-const intended = releasesCreated || forcePublish
-const releaseResult = process.env.RELEASE_RESULT ?? 'unknown'
-const buildResult = process.env.BUILD_RESULT ?? 'unknown'
-const publishResult = process.env.PUBLISH_RESULT ?? 'unknown'
-const verifyResult = process.env.VERIFY_RESULT ?? 'unknown'
-const releaseFailed = releaseResult !== 'success'
-const state = !intended && !releaseFailed
-  ? 'NO_RELEASE'
-  : releaseResult === 'success' && buildResult === 'success' && publishResult === 'success' && verifyResult === 'success'
-    ? 'PUBLISHED'
-    : 'FAILED'
+const releasesCreated = process.env.RELEASES_CREATED === "true";
+const forcePublish = process.env.FORCE_PUBLISH === "true";
+const intended = releasesCreated || forcePublish;
+const releaseResult = process.env.RELEASE_RESULT ?? "unknown";
+const buildResult = process.env.BUILD_RESULT ?? "unknown";
+const publishResult = process.env.PUBLISH_RESULT ?? "unknown";
+const verifyResult = process.env.VERIFY_RESULT ?? "unknown";
+const releaseFailed = releaseResult !== "success";
+const state =
+  !intended && !releaseFailed
+    ? "NO_RELEASE"
+    : releaseResult === "success" &&
+        buildResult === "success" &&
+        publishResult === "success" &&
+        verifyResult === "success"
+      ? "PUBLISHED"
+      : "FAILED";
 
 const lines = [
   `## Ferriki release outcome: ${state}`,
-  '',
-  `- npm dist-tag: \`${process.env.NPM_DIST_TAG ?? 'latest'}\``,
+  "",
+  `- npm dist-tag: \`${process.env.NPM_DIST_TAG ?? "latest"}\``,
   `- release-please: \`${releaseResult}\` (releases created: \`${releasesCreated}\`)`,
   `- native build matrix: \`${buildResult}\``,
   `- npm publication: \`${publishResult}\``,
   `- public registry/install verification: \`${verifyResult}\``,
-]
-const summary = `${lines.join('\n')}\n`
-console.log(summary)
-if (process.env.GITHUB_STEP_SUMMARY)
-  await appendFile(process.env.GITHUB_STEP_SUMMARY, summary)
+];
+const summary = `${lines.join("\n")}\n`;
+console.log(summary);
+if (process.env.GITHUB_STEP_SUMMARY) await appendFile(process.env.GITHUB_STEP_SUMMARY, summary);
 
-if (state === 'FAILED')
-  process.exitCode = 1
+if (state === "FAILED") process.exitCode = 1;

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -15,14 +15,12 @@
     "skipDefaultLibCheck": true,
     "skipLibCheck": true
   },
-  "include": [
-    "**/*.ts",
-    "**/*.mjs",
-    "eslint.config.js"
-  ],
+  "include": ["**/*.ts", "**/*.mjs", "eslint.config.js"],
   "exclude": [
     "**/node_modules/**",
     "**/dist/**",
-    "compat/upstream/**"
+    "compat/upstream/**",
+    "eslint.config.ts",
+    "oxlint.config.ts"
   ]
 }

--- a/node/vitest.config.ts
+++ b/node/vitest.config.ts
@@ -1,14 +1,14 @@
-import process from 'node:process'
-import tsconfigPaths from 'vite-tsconfig-paths'
-import { defineConfig } from 'vitest/config'
+import process from "node:process";
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
 
 function compatPackage(entry: string) {
-  return new URL(`./compat/upstream/shiki/packages/${entry}`, import.meta.url).pathname
+  return new URL(`./compat/upstream/shiki/packages/${entry}`, import.meta.url).pathname;
 }
 
-const ferrikiEntry = new URL('./ferriki/index.mjs', import.meta.url).pathname
-const virtualLangPrefix = '\0ferriki:lang:'
-const virtualThemePrefix = '\0ferriki:theme:'
+const ferrikiEntry = new URL("./ferriki/index.mjs", import.meta.url).pathname;
+const virtualLangPrefix = "\0ferriki:lang:";
+const virtualThemePrefix = "\0ferriki:theme:";
 
 function defaultExportInteropExpression(source: string) {
   return [
@@ -16,10 +16,10 @@ function defaultExportInteropExpression(source: string) {
     `Object.values(${source}).find(value => value && typeof value === 'object' && 'default' in value)?.default`,
     `Object.values(${source}).find(value => Array.isArray(value))`,
     `${source}`,
-  ].join(' ?? ')
+  ].join(" ?? ");
 }
 
-const backendEntry = new URL('./compat/harness/shiki-backend-entry.ts', import.meta.url).pathname
+const backendEntry = new URL("./compat/harness/shiki-backend-entry.ts", import.meta.url).pathname;
 
 export default defineConfig({
   plugins: [
@@ -28,59 +28,59 @@ export default defineConfig({
       // tests' remaining upstream entry points through the ferriki backend
       // entry, so the compat lane exercises the native path instead of
       // upstream JS against upstream JS (migration plan, Finding 0).
-      name: 'ferriki-honest-alias',
-      enforce: 'pre' as const,
+      name: "ferriki-honest-alias",
+      enforce: "pre" as const,
       resolveId(source: string, importer?: string) {
-        if (!process.env.FERRIKI_HONEST_ALIAS)
-          return
-        if (source === 'shiki/bundle/full' || source === 'shiki/core')
-          return backendEntry
+        if (!process.env.FERRIKI_HONEST_ALIAS) return;
+        if (source === "shiki/bundle/full" || source === "shiki/core") return backendEntry;
         if (
-          source === '@shikijs/engine-javascript'
-          || source === '@shikijs/engine-oniguruma'
-          || source === '@shikijs/engine-oniguruma/wasm-inlined'
+          source === "@shikijs/engine-javascript" ||
+          source === "@shikijs/engine-oniguruma" ||
+          source === "@shikijs/engine-oniguruma/wasm-inlined"
         ) {
-          return backendEntry
+          return backendEntry;
         }
-        if (source === '../src' && importer && (
-          importer.includes('/compat/upstream/shiki/packages/shiki/test/')
-          || importer.includes('/compat/upstream/shiki/packages/core/test/')
-        )) {
-          return backendEntry
+        if (
+          source === "../src" &&
+          importer &&
+          (importer.includes("/compat/upstream/shiki/packages/shiki/test/") ||
+            importer.includes("/compat/upstream/shiki/packages/core/test/"))
+        ) {
+          return backendEntry;
         }
       },
     },
     tsconfigPaths(),
     {
-      name: 'ferriki-compat-subpath-loader',
+      name: "ferriki-compat-subpath-loader",
       resolveId(id) {
-        if (id.startsWith('@shikijs/langs/'))
-          return `${virtualLangPrefix}${id.slice('@shikijs/langs/'.length)}`
-        if (id.startsWith('@shikijs/themes/'))
-          return `${virtualThemePrefix}${id.slice('@shikijs/themes/'.length)}`
+        if (id.startsWith("@shikijs/langs/"))
+          return `${virtualLangPrefix}${id.slice("@shikijs/langs/".length)}`;
+        if (id.startsWith("@shikijs/themes/"))
+          return `${virtualThemePrefix}${id.slice("@shikijs/themes/".length)}`;
       },
       load(id) {
         if (id.startsWith(virtualLangPrefix)) {
-          const lang = id.slice(virtualLangPrefix.length)
+          const lang = id.slice(virtualLangPrefix.length);
           return `
 import { bundledLanguages } from ${JSON.stringify(ferrikiEntry)}
 const loader = bundledLanguages[${JSON.stringify(lang)}]
 if (!loader)
   throw new Error(${JSON.stringify(`Unknown Ferriki bundled language: ${lang}`)})
 const loaded = await loader()
-export default ${defaultExportInteropExpression('loaded')}
-`
+export default ${defaultExportInteropExpression("loaded")}
+`;
         }
         if (id.startsWith(virtualThemePrefix)) {
-          const theme = id.slice(virtualThemePrefix.length)
+          const theme = id.slice(virtualThemePrefix.length);
           return `
 import { bundledThemes } from ${JSON.stringify(ferrikiEntry)}
 const loader = bundledThemes[${JSON.stringify(theme)}]
 if (!loader)
   throw new Error(${JSON.stringify(`Unknown Ferriki bundled theme: ${theme}`)})
 const loaded = await loader()
-export default ${defaultExportInteropExpression('loaded')}
-`
+export default ${defaultExportInteropExpression("loaded")}
+`;
         }
       },
     },
@@ -89,69 +89,67 @@ export default ${defaultExportInteropExpression('loaded')}
     alias: [
       {
         find: /^shiki$/,
-        replacement: new URL('./compat/harness/shiki-backend-entry.ts', import.meta.url).pathname,
+        replacement: new URL("./compat/harness/shiki-backend-entry.ts", import.meta.url).pathname,
       },
       {
         find: /^@shikijs\/primitive$/,
-        replacement: compatPackage('primitive/src/index.ts'),
+        replacement: compatPackage("primitive/src/index.ts"),
       },
       {
         find: /^@shikijs\/primitive\/textmate$/,
-        replacement: compatPackage('primitive/src/textmate/index.ts'),
+        replacement: compatPackage("primitive/src/textmate/index.ts"),
       },
       {
         find: /^@shikijs\/core$/,
-        replacement: compatPackage('core/src/index.ts'),
+        replacement: compatPackage("core/src/index.ts"),
       },
       {
         find: /^@shikijs\/core\/textmate$/,
-        replacement: compatPackage('core/src/textmate.ts'),
+        replacement: compatPackage("core/src/textmate.ts"),
       },
       {
         find: /^@shikijs\/engine-javascript$/,
         replacement: process.env.FERRIKI_HONEST_ALIAS
           ? backendEntry
-          : compatPackage('engine-javascript/src/index.ts'),
+          : compatPackage("engine-javascript/src/index.ts"),
       },
       {
         find: /^@shikijs\/engine-oniguruma$/,
         replacement: process.env.FERRIKI_HONEST_ALIAS
           ? backendEntry
-          : compatPackage('engine-oniguruma/src/index.ts'),
+          : compatPackage("engine-oniguruma/src/index.ts"),
       },
       {
         find: /^@shikijs\/engine-oniguruma\/wasm-inlined$/,
         replacement: process.env.FERRIKI_HONEST_ALIAS
           ? backendEntry
-          : compatPackage('engine-oniguruma/src/wasm-inlined.ts'),
+          : compatPackage("engine-oniguruma/src/wasm-inlined.ts"),
       },
       {
         find: /^@shikijs\/transformers$/,
-        replacement: compatPackage('transformers/src/index.ts'),
+        replacement: compatPackage("transformers/src/index.ts"),
       },
       {
         find: /^@shikijs\/twoslash$/,
-        replacement: compatPackage('twoslash/src/index.ts'),
+        replacement: compatPackage("twoslash/src/index.ts"),
       },
       {
         find: /^@shikijs\/types$/,
-        replacement: compatPackage('types/src/index.ts'),
+        replacement: compatPackage("types/src/index.ts"),
       },
       {
         find: /^ferriki$/,
-        replacement: new URL('./ferriki/index.mjs', import.meta.url).pathname,
+        replacement: new URL("./ferriki/index.mjs", import.meta.url).pathname,
       },
       {
         find: /^ferriki\/native$/,
-        replacement: new URL('./ferriki/native.mjs', import.meta.url).pathname,
+        replacement: new URL("./ferriki/native.mjs", import.meta.url).pathname,
       },
     ],
   },
   test: {
     testTimeout: 30_000,
-    reporters: 'dot',
-    exclude: [
-      '**/node_modules/**',
-    ],
+    reporters: "dot",
+    exclude: ["**/node_modules/**"],
   },
-})
+});

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sebastian-software/renovate-config"]
+  "extends": ["github>sebastian-software/renovate-config"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Keep the pinned standards CLI in the workflows current",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": ["@sebastian-software/standards@(?<currentValue>[^\\s]+) "],
+      "depNameTemplate": "@sebastian-software/standards",
+      "datasourceTemplate": "npm"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Stamps the repository at `@sebastian-software/standards` manifest version 12 and walks the judgement steps of changes 0010 (private reporting routes), 0011 (pinned standards CLI) and 0012 (nested Node workspaces). The Node workspace in `node/` receives the node scope for the first time, which is the substance of this pull request.

## Changes

**Before.** `standards check` at 0.9.0 reported one finding, the version-9 stamp. Nothing else — because `node` detects on a root `package.json` and this repository is Rust-only at the root, so the whole node scope was invisible.

**Workspace declaration (0012).** `.repometa.json` gains `"workspaces": ["node"]`. Candidates and verdicts:

| Candidate | Verdict |
| --- | --- |
| `node/` | **declared** — own `package.json`, `pnpm-workspace.yaml`, lockfile and configs; the CI `lint` and `typecheck` jobs run in it |
| `node/ferriki/`, `node/platforms/*` | not declared — members of that pnpm workspace; the five platform packages are install-time native sidecars |
| `node/compat/upstream/**` (15 manifests) | not declared — the mechanical Shiki and vscode-textmate mirror (ADR 0003) |

`check` then reported four more findings and `apply` wrote them: managed `node/.oxfmtrc.json`, seeded `node/eslint.config.ts`, `node/oxlint.config.ts`, `node/cspell.json`. `node/tsconfig.json` already existed and was left alone, as seeding intends. The second `check` is clean.

**The upstream mirror is not formatted or linted.** The managed `.oxfmtrc.json` is standards property and must not carry repository-specific ignores, so `compat/upstream/` (and the generated `.generated/`) go into a repository-local `node/.prettierignore`, which oxfmt auto-discovers — the escape hatch change 0005 names. ESLint already ignored the mirror. Nothing under `node/compat/upstream/` is touched by this pull request.

**Formatter adoption (0001 and 0012, node scope, first pass).** `oxfmt` becomes a devDependency through the `cli` catalog, with `format` / `format:check` scripts that run from `node/` so the workspace config applies. Three follow-on decisions were needed:

- `@antfu/eslint-config` takes `stylistic: false`, and `jsonc/sort-keys` and `unicorn/number-literal-case` are off. All three disagree with oxfmt about quotes, semicolons, package.json key order and hex-literal casing; leaving them on produced 4369 errors that only a formatter should decide.
- The generated wrapper files are now written in the shape oxfmt produces. `build-wrapper.mjs` and `verify-wrapper.mjs` held two copies of their expected bytes; those move to a shared `wrapper-contents.mjs`, and the declaration copy is formatted in the generator step. Otherwise `pnpm run build` and `pnpm run format:check` would each undo the other and `check:api` would fail.
- `public-api-types.typecheck.ts` asserted an excess property with a `@ts-expect-error` above a one-line object literal. oxfmt wraps that literal, which moves the reported error off the directive's line, so the directive now sits on the property it is about.

The formatting itself is a separate `style:` commit, 63 files, behavior unchanged.

**Lint rules are deliberately not adopted — #110.** Both seeded configs import `eslint-config-setup`, whose peer range is `eslint >= 10`, while the workspace resolves ESLint from the `cli` catalog entry `^9.39.2` that the mirrored Shiki packages share. That bump is not a local decision, so `node/eslint.config.js` stays the entry point and the two seeded files are excluded from ESLint and from `tsc` until the migration lands. An `oxlint` probe with the default rule set found 6 warnings in the repository's own Node code, so the fallout looks small; the issue carries the numbers and the task list.

**Private reporting routes (0010).** `CODE_OF_CONDUCT.md` took the seed's Reporting section: it offered "the repository maintainers, through GitHub", a channel GitHub does not have. The issue chooser now offers both routes — the inbox first, linked to this repository's `SECURITY.md` because a `mailto:` entry is dropped from the chooser, and the private advisory second, which 404s until private vulnerability reporting is enabled for this repository. There were no repository-specific extra links to preserve.

**Pinned standards CLI (0011).** This repository had no `standards check` lane at all, so one is added from `reference/rust/ci.yml`, with the `.standards/pending.json` guard and the CLI pinned at `@0.9.0` in the command — a Rust-only root has no lockfile to hold it. `pnpm/action-setup` reads `node/package.json` for its version, matching the other Node jobs. `renovate.json` gains the custom manager from `reference/rust/README.md` that moves the pin.

Wave 4a's `scripts/sync-readme-family.mjs` and its CI step are untouched, and its `--check` form still passes: the generator compares content, not whitespace, so oxfmt reflowing `node/ferriki/README.md` is not drift.

## Validation

Per the wave brief, no `build:native` and no compatibility suites; formatting and the Node workspace's own checks are the gate.

- `pnpm --config.minimum-release-age=0 dlx @sebastian-software/standards@0.9.0 check` — 1 finding before, 5 after declaring the workspace, `✓ Repository matches org standards` after `apply`
- `cargo fmt --all --check` — clean
- `node/`: `pnpm install --frozen-lockfile --ignore-scripts`, `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run check:api`, `pnpm run check:release` — all pass
- `node/`: `pnpm run typecheck` — the six pre-existing `compat/harness/honest-alias.test.ts` module-resolution errors that `build:compat` resolves in CI, identical to the count on `origin/main`; no new errors
- `node scripts/check-workflow-pins.mjs`, `node scripts/test-check-workflow-pins.mjs`, `node scripts/sync-readme-family.mjs --check` — all pass

Left for the owner: enable private vulnerability reporting (`gh api -X PUT repos/sebastian-software/ferriki/private-vulnerability-reporting`), which no CLI can set and without which the advisory link 404s.

## Issue

Refs #93
Refs #95
Refs #110
Refs sebastian-software/ferramenta#6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFZKSZqbtZnUT5tSVEB81M

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFZKSZqbtZnUT5tSVEB81M)_