### PR TITLE
ci: smoke test packed release artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -206,6 +206,12 @@ jobs:
           done
           pnpm run check:docs
 
+      # Publish only after the generated main-package tarball installs and loads
+      # in a clean consumer. The native-smoke matrix runs this on every target;
+      # this repeats the Linux release artifact check immediately before npm.
+      - name: Verify packed main-package consumer
+        run: node ./scripts/check-packed-consumer.mjs
+
       - name: Publish platform packages with npm provenance
         working-directory: node
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -204,7 +204,7 @@ jobs:
           for platform_id in linux-x64-gnu linux-arm64-gnu darwin-arm64 darwin-x64 win32-x64-msvc; do
             FERRIKI_PLATFORM_ID="$platform_id" pnpm run check:platform-package
           done
-          pnpm run check:docs
+          node ./scripts/check-docs-contract.mjs
 
       # Publish only after the generated main-package tarball installs and loads
       # in a clean consumer. The native-smoke matrix runs this on every target;

--- a/node/package.json
+++ b/node/package.json
@@ -26,7 +26,7 @@
     "check:api": "node ./scripts/check-generated-api.mjs",
     "check:api-contract": "node ./scripts/check-ferriki-api-contract.mjs",
     "check:boundary": "node ./scripts/check-native-boundary.mjs",
-    "check:release": "node ./scripts/check-release-workflow.mjs && node ./scripts/test-npm-publish-verification.mjs",
+    "check:release": "node ./scripts/check-release-workflow.mjs && node ./scripts/test-release-workflow-contract.mjs && node ./scripts/test-npm-publish-verification.mjs",
     "check:transformers": "node ./scripts/check-ferriki-transformers.mjs",
     "check:token-state": "node ./scripts/check-ferriki-token-state.mjs",
     "check:ferromark-ardo": "node ./scripts/check-ferromark-ardo-contract.mjs",

--- a/node/scripts/check-release-workflow.mjs
+++ b/node/scripts/check-release-workflow.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 function publishJob(workflow) {
@@ -8,7 +9,7 @@ function publishJob(workflow) {
   const start = workflow.indexOf(startMarker);
   assert(start >= 0, "release workflow is missing publish-npm job");
   const body = workflow.slice(start + startMarker.length);
-  const nextJob = body.search(/\n  [a-z0-9-]+:\s*\n/);
+  const nextJob = body.search(/\n {2}[a-z0-9-]+:\s*\n/);
   return body.slice(0, nextJob >= 0 ? nextJob : body.length);
 }
 

--- a/node/scripts/check-release-workflow.mjs
+++ b/node/scripts/check-release-workflow.mjs
@@ -3,102 +3,129 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const nodeRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
-const repoRoot = join(nodeRoot, "..");
-const workflow = await readFile(join(repoRoot, ".github/workflows/publish.yml"), "utf8");
-const checklist = await readFile(join(repoRoot, "docs/release-checklist.md"), "utf8");
-const releaseConfig = JSON.parse(
-  await readFile(join(repoRoot, ".release-please-config.json"), "utf8"),
-);
-const releasePackage = releaseConfig.packages?.["node/ferriki"];
-const extraFiles = releasePackage?.["extra-files"] ?? [];
+function publishJob(workflow) {
+  const startMarker = "\n  publish-npm:\n";
+  const start = workflow.indexOf(startMarker);
+  assert(start >= 0, "release workflow is missing publish-npm job");
+  const body = workflow.slice(start + startMarker.length);
+  const nextJob = body.search(/\n  [a-z0-9-]+:\s*\n/);
+  return body.slice(0, nextJob >= 0 ? nextJob : body.length);
+}
 
-assert.match(
-  workflow,
-  /googleapis\/release-please-action@[0-9a-f]{40}/,
-  "release workflow must pin release-please to an immutable commit",
-);
-assert.doesNotMatch(
-  workflow,
-  /uses: [^\n]+@(main|master|v\d)/,
-  "release workflow must not follow mutable action refs",
-);
-assert.equal(
-  releaseConfig["release-type"],
-  "node",
-  "Ferriki release authority must remain the Node package",
-);
-assert.equal(
-  releaseConfig["include-component-in-tag"],
-  false,
-  "Ferriki must preserve the unscoped product tag format",
-);
-assert.equal(
-  releasePackage?.["changelog-path"],
-  "CHANGELOG.md",
-  "release package must declare its changelog path",
-);
-assert(
-  extraFiles.some(
-    (file) =>
-      file.path === "/node/ferriki/package.json" && file.jsonpath === "$.optionalDependencies[*]",
-  ),
-  "release config must update all platform dependency versions with the product version",
-);
-assert(
-  extraFiles.some(
-    (file) =>
-      file.path === "/node/platforms/*/package.json" &&
-      file.glob === true &&
-      file.jsonpath === "$.version",
-  ),
-  "release config must update every platform package manifest with the product version",
-);
-assert(
-  extraFiles.some(
-    (file) =>
-      file.path === "/node/pnpm-lock.yaml" &&
-      file.type === "yaml" &&
-      file.jsonpath === "$.importers.ferriki.optionalDependencies[*].specifier",
-  ),
-  "release config must update the pnpm lockfile dependency specifiers",
-);
-assert.doesNotMatch(
-  workflow,
-  /sync:platform-versions/,
-  "release workflow must not patch generated release candidates",
-);
-for (const job of [
-  "release-please:",
-  "build-native:",
-  "publish-npm:",
-  "verify-npm-publish:",
-  "release-summary:",
-])
-  assert(workflow.includes(`  ${job}`), `release workflow is missing ${job}`);
-for (const required of [
-  "force-publish:",
-  "dist-tag:",
-  "timeout-minutes:",
-  "actions/download-artifact@",
-  "check-packed-consumer.mjs",
-  "npm publish --access public --provenance",
-  "NPM_PUBLISH_RESULT:",
-  "write-release-summary.mjs",
-])
-  assert(workflow.includes(required), `release workflow is missing ${required}`);
+export function assertReleaseWorkflow({ workflow, checklist, releaseConfig }) {
+  const releasePackage = releaseConfig.packages?.["node/ferriki"];
+  const extraFiles = releasePackage?.["extra-files"] ?? [];
 
-for (const required of [
-  "npm provenance",
-  "GitHub release",
-  "tarball",
-  "rollback",
-  "deprecate",
-  "go/no-go",
-])
+  assert.match(
+    workflow,
+    /googleapis\/release-please-action@[0-9a-f]{40}/,
+    "release workflow must pin release-please to an immutable commit",
+  );
+  assert.doesNotMatch(
+    workflow,
+    /uses: [^\n]+@(main|master|v\d)/,
+    "release workflow must not follow mutable action refs",
+  );
+  assert.equal(
+    releaseConfig["release-type"],
+    "node",
+    "Ferriki release authority must remain the Node package",
+  );
+  assert.equal(
+    releaseConfig["include-component-in-tag"],
+    false,
+    "Ferriki must preserve the unscoped product tag format",
+  );
+  assert.equal(
+    releasePackage?.["changelog-path"],
+    "CHANGELOG.md",
+    "release package must declare its changelog path",
+  );
   assert(
-    checklist.toLowerCase().includes(required.toLowerCase()),
-    `release checklist is missing ${required}`,
+    extraFiles.some(
+      (file) =>
+        file.path === "/node/ferriki/package.json" && file.jsonpath === "$.optionalDependencies[*]",
+    ),
+    "release config must update all platform dependency versions with the product version",
+  );
+  assert(
+    extraFiles.some(
+      (file) =>
+        file.path === "/node/platforms/*/package.json" &&
+        file.glob === true &&
+        file.jsonpath === "$.version",
+    ),
+    "release config must update every platform package manifest with the product version",
+  );
+  assert(
+    extraFiles.some(
+      (file) =>
+        file.path === "/node/pnpm-lock.yaml" &&
+        file.type === "yaml" &&
+        file.jsonpath === "$.importers.ferriki.optionalDependencies[*].specifier",
+    ),
+    "release config must update the pnpm lockfile dependency specifiers",
+  );
+  assert.doesNotMatch(
+    workflow,
+    /sync:platform-versions/,
+    "release workflow must not patch generated release candidates",
+  );
+  for (const job of [
+    "release-please:",
+    "build-native:",
+    "publish-npm:",
+    "verify-npm-publish:",
+    "release-summary:",
+  ])
+    assert(workflow.includes(`  ${job}`), `release workflow is missing ${job}`);
+  for (const required of [
+    "force-publish:",
+    "dist-tag:",
+    "timeout-minutes:",
+    "actions/download-artifact@",
+    "npm publish --access public --provenance",
+    "NPM_PUBLISH_RESULT:",
+    "write-release-summary.mjs",
+  ])
+    assert(workflow.includes(required), `release workflow is missing ${required}`);
+
+  const publishWorkflow = publishJob(workflow);
+  const smokeMatch = publishWorkflow.match(
+    /^[ \t]+run:[ \t]+node \.\/scripts\/check-packed-consumer\.mjs\s*$/m,
+  );
+  assert(smokeMatch, "publish-npm must run an executable packed-consumer smoke command");
+  const firstPublicationMatch = publishWorkflow.match(
+    /^[ \t]+(?:run:[ \t]+)?npm publish\b/m,
+  );
+  assert(firstPublicationMatch, "publish-npm must contain an npm publication step");
+  assert(
+    smokeMatch.index < firstPublicationMatch.index,
+    "packed-consumer smoke command must precede the first npm publication step",
   );
 
-console.log("Ferriki release workflow and checklist verified");
+  for (const required of [
+    "npm provenance",
+    "GitHub release",
+    "tarball",
+    "rollback",
+    "deprecate",
+    "go/no-go",
+  ])
+    assert(
+      checklist.toLowerCase().includes(required.toLowerCase()),
+      `release checklist is missing ${required}`,
+    );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const nodeRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+  const repoRoot = join(nodeRoot, "..");
+  const workflow = await readFile(join(repoRoot, ".github/workflows/publish.yml"), "utf8");
+  const checklist = await readFile(join(repoRoot, "docs/release-checklist.md"), "utf8");
+  const releaseConfig = JSON.parse(
+    await readFile(join(repoRoot, ".release-please-config.json"), "utf8"),
+  );
+  assertReleaseWorkflow({ workflow, checklist, releaseConfig });
+  console.log("Ferriki release workflow and checklist verified");
+}

--- a/node/scripts/check-release-workflow.mjs
+++ b/node/scripts/check-release-workflow.mjs
@@ -81,6 +81,7 @@ for (const required of [
   "dist-tag:",
   "timeout-minutes:",
   "actions/download-artifact@",
+  "check-packed-consumer.mjs",
   "npm publish --access public --provenance",
   "NPM_PUBLISH_RESULT:",
   "write-release-summary.mjs",

--- a/node/scripts/test-release-workflow-contract.mjs
+++ b/node/scripts/test-release-workflow-contract.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { assertReleaseWorkflow } from "./check-release-workflow.mjs";
+
+const nodeRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const repoRoot = join(nodeRoot, "..");
+const workflowPath = join(repoRoot, ".github", "workflows", "publish.yml");
+const workflow = await readFile(workflowPath, "utf8");
+const checklist = await readFile(join(repoRoot, "docs", "release-checklist.md"), "utf8");
+const releaseConfig = JSON.parse(
+  await readFile(join(repoRoot, ".release-please-config.json"), "utf8"),
+);
+
+assert.doesNotThrow(() => assertReleaseWorkflow({ workflow, checklist, releaseConfig }));
+
+const smokeStep =
+  "      - name: Verify packed main-package consumer\n" +
+  "        run: node ./scripts/check-packed-consumer.mjs\n\n";
+assert.equal(workflow.match(new RegExp(smokeStep, "g"))?.length, 1);
+
+const commandReplacedWithVersionCheck = workflow.replace(
+  smokeStep,
+  "      - name: Verify packed main-package consumer\n" +
+    "        run: node --version\n" +
+    "        # node ./scripts/check-packed-consumer.mjs\n\n",
+);
+assert.throws(
+  () =>
+    assertReleaseWorkflow({
+      workflow: commandReplacedWithVersionCheck,
+      checklist,
+      releaseConfig,
+    }),
+  /executable packed-consumer smoke command/,
+);
+
+const withoutSmokeStep = workflow.replace(smokeStep, "");
+const mainPublicationStep = "      - name: Publish main package with npm provenance\n";
+const mainPublicationOffset = withoutSmokeStep.indexOf(mainPublicationStep);
+assert(mainPublicationOffset >= 0, "fixture must contain the main publication step");
+const smokeStepMovedAfterPublication =
+  withoutSmokeStep.slice(0, mainPublicationOffset) +
+  smokeStep +
+  withoutSmokeStep.slice(mainPublicationOffset);
+assert.throws(
+  () =>
+    assertReleaseWorkflow({
+      workflow: smokeStepMovedAfterPublication,
+      checklist,
+      releaseConfig,
+    }),
+  /must precede the first npm publication step/,
+);
+
+console.log("Ferriki release workflow command and order contract verified");


### PR DESCRIPTION
## Summary

- run the existing clean `npm pack` consumer smoke after assembling the coordinated release artifacts and before any npm publication
- contract-check that the publish workflow keeps that safeguard
- retain the already-merged #54 runner replacement, immutable action pins, sidecar matrix, trusted-publishing configuration, and explicit release summary

## Validation

- `git diff --check`
- Required GitHub Actions CI: passed (all checks green, including all five native-smoke targets)
- Local Node checks: not run because this worktree host has no `node` executable or installed workspace dependencies

## Remaining release authority

After this PR is merged and CI is green, an authorized maintainer must dispatch `Publish` with `force-publish=true` and `dist-tag=next`, with npm Trusted Publishing configured for `ferriki` and its five sidecars. This PR does not publish, create a release, or change external account configuration.

Refs #15

🔧 Emily Carter · Implementation Agent